### PR TITLE
Sync all configured installations

### DIFF
--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -44,10 +44,11 @@ Go to your GitHub app page on `https://github.com/apps/YOUR_APP_NAME` and instal
 
 ## Configure Board
 
-Setup a `packages/app/wuffle.config.js` file describing all repositories your board should synchronize:
+Setup a `packages/app/wuffle.config.js` file, configuring the board:
 
 ```js
 module.exports = {
+  name: 'My Wuffle Board',
   columns: [
     { name: 'Inbox', label: null },
     { name: 'Backlog', label: 'backlog', sorting: true },
@@ -55,20 +56,16 @@ module.exports = {
     { name: 'In Progress', label: 'in progress' },
     { name: 'Needs Review', label: 'needs review' },
     { name: 'Done', label: null, closed: true }
-  ],
-  repositories: [
-    'org1/repo1',
-    'org2/repo2'
   ]
 };
 ```
 
-Make sure that you [configured your app](#configure-github-app) for all these repositories.
+Make sure that you [enabled your app](#configure-github-app) for all repositories that you would like to connect to the board.
 
 
 ## Run Board
 
-If you started your app in development mode the board should reload automatically. If properly configured, background sync will pickup configured repositories, fetch issues from GitHub and populate your board.
+If you started your app in development mode the board should reload automatically. If properly configured, background sync will pickup repositories, fetch issues from GitHub and populate your board.
 
 ### Run in Production
 

--- a/packages/app/lib/apps/background-sync.js
+++ b/packages/app/lib/apps/background-sync.js
@@ -23,27 +23,17 @@ module.exports = async (app, config, store) => {
     name: 'wuffle:background-sync'
   });
 
-  const {
-    repositories
-  } = config;
 
-  if (repositories.length === 0) {
-    return log.error(
-      'must declare <config.repositories> to let wuffle know which repositories should be synched in background'
+  if ('repositories' in config) {
+
+    log.warn(`
+Configuring repositories via wuffle.config.js got removed, please update your config.
+
+We automatically synchronize all repositories you granted us access to via the GitHub app.
+`
     );
   }
 
-  function fetchRepository(repositoryName) {
-
-    const [ owner, repo ] = repositoryName.split('/');
-
-    return app.orgAuth(owner).then(github => {
-      return github.repos.get({
-        owner,
-        repo
-      });
-    }).then(res => res.data);
-  }
 
   async function applyUpdate(update) {
 
@@ -73,110 +63,167 @@ module.exports = async (app, config, store) => {
     return applyUpdate(filterIssue(issue, repository));
   }
 
-  async function syncRepositories(repositories, since) {
+  async function syncInstallation(installation, since) {
 
     const foundIssues = {};
 
-    // sync issues
-    for (const repositoryName of repositories) {
-      const [ owner, repo ] = repositoryName.split('/');
+    const owner = installation.account.login;
 
-      const params = {
-        sort: 'updated',
-        direction: 'desc',
-        owner,
-        repo
-      };
+    log.debug({ installation: owner }, 'sync start');
 
-      log.debug({ repositoryName }, 'issues sync start');
+    try {
+      const github = await app.orgAuth(owner);
 
-      try {
-        const github = await app.orgAuth(owner);
+      const repositories = await github.paginate(
+        github.apps.listRepos.endpoint.merge({ per_page: 100 }),
+        (response) => response.data
+      );
 
-        const [
-          open_issues,
-          closed_issues,
-          open_pull_requests,
-          closed_pull_requests,
-          repository
-        ] = await Promise.all([
+      for (const repository of repositories) {
 
-          // open issues
-          github.paginate(
-            github.issues.listForRepo.endpoint.merge({
-              ...params,
-              state: 'open'
-            }),
-            (response) => response.data.filter(issue => !issue.pull_request)
-          ),
+        const owner = repository.owner.login;
+        const repo = repository.name;
 
-          // closed issues, updated last 30 days
-          github.paginate(
-            github.issues.listForRepo.endpoint.merge({
-              ...params,
-              state: 'closed',
-              since: new Date(since).toISOString()
-            }),
-            (response) => response.data.filter(issue => !issue.pull_request)
-          ),
+        try {
 
-          // open pulls
-          github.paginate(
-            github.pulls.list.endpoint.merge({
-              ...params,
-              state: 'open'
-            }),
-            (response) => response.data
-          ),
+          log.debug({
+            owner,
+            repo
+          }, 'sync start');
 
-          // closed pulls, updated last 30 days
-          github.paginate(
-            github.pulls.list.endpoint.merge({
-              ...params,
-              state: 'closed'
-            }),
-            (response, done) => {
+          const params = {
+            sort: 'updated',
+            direction: 'desc',
+            owner,
+            repo
+          };
 
-              const pulls = response.data;
+          const [
+            open_issues,
+            closed_issues,
+            open_pull_requests,
+            closed_pull_requests
+          ] = await Promise.all([
 
-              const filtered = pulls.filter(pull => new Date(pull.updated_at).getTime() > since);
+            // open issues
+            github.paginate(
+              github.issues.listForRepo.endpoint.merge({
+                ...params,
+                state: 'open'
+              }),
+              (response) => response.data.filter(issue => !issue.pull_request)
+            ),
 
-              if (filtered.length !== pulls.length) {
-                done();
+            // closed issues, updated last 30 days
+            github.paginate(
+              github.issues.listForRepo.endpoint.merge({
+                ...params,
+                state: 'closed',
+                since: new Date(since).toISOString()
+              }),
+              (response) => response.data.filter(issue => !issue.pull_request)
+            ),
+
+            // open pulls
+            github.paginate(
+              github.pulls.list.endpoint.merge({
+                ...params,
+                state: 'open'
+              }),
+              (response) => response.data
+            ),
+
+            // closed pulls, updated last 30 days
+            github.paginate(
+              github.pulls.list.endpoint.merge({
+                ...params,
+                state: 'closed'
+              }),
+              (response, done) => {
+
+                const pulls = response.data;
+
+                const filtered = pulls.filter(pull => new Date(pull.updated_at).getTime() > since);
+
+                if (filtered.length !== pulls.length) {
+                  done();
+                }
+
+                return filtered;
               }
+            )
+          ]);
 
-              return filtered;
+          for (const issue of [ ...open_issues, ...closed_issues ]) {
+
+            try {
+              const {
+                id
+              } = await syncIssue(issue, repository);
+
+              // mark as found
+              foundIssues[id] = true;
+            } catch (error) {
+              log.debug({
+                owner,
+                repo,
+                issue: issue.number
+              }, 'sync failed', error);
             }
-          ),
+          }
 
-          // repository information
-          fetchRepository(repositoryName)
-        ]);
+          for (const pull_request of [ ...open_pull_requests, ...closed_pull_requests ]) {
 
-        for (const issue of [ ...open_issues, ...closed_issues ]) {
+            try {
+              const {
+                id
+              } = await syncPull(pull_request, repository);
 
-          const {
-            id
-          } = await syncIssue(issue, repository);
+              // mark as found
+              foundIssues[id] = true;
+            } catch (error) {
+              log.debug({
+                owner,
+                repo,
+                pr: pull_request.number
+              }, 'sync failed', error);
+            }
+          }
 
-          // mark as found
-          foundIssues[id] = true;
+          log.debug({
+            owner,
+            repo
+          }, 'sync completed');
+        } catch (error) {
+          log.warn({
+            owner,
+            repo
+          }, 'sync failed', error);
         }
 
-        for (const pull_request of [ ...open_pull_requests, ...closed_pull_requests ]) {
+      } // end --- for (const repository of repositories)
 
-          const {
-            id
-          } = await syncPull(pull_request, repository);
+      log.debug({ installation: owner }, 'sync completed');
+    } catch (error) {
+      log.warn({ installation: owner }, 'sync failed', error);
+    }
 
-          // mark as found
-          foundIssues[id] = true;
-        }
+    return foundIssues;
+  }
 
-        log.debug({ repositoryName }, 'issues sync completed');
-      } catch (error) {
-        log.warn({ repositoryName }, 'issues sync failed', error);
-      }
+  async function syncInstallations(installations, since) {
+
+    let foundIssues = {};
+
+    // sync issues
+    for (const installation of installations) {
+
+      const installationIssues = await syncInstallation(installation, since);
+
+      foundIssues = {
+        ...foundIssues,
+        ...installationIssues
+      };
     }
 
     return foundIssues;
@@ -217,7 +264,7 @@ module.exports = async (app, config, store) => {
     return expired;
   }
 
-  async function doSync(repositories) {
+  async function doSync(installations) {
 
     const now = Date.now();
 
@@ -229,7 +276,7 @@ module.exports = async (app, config, store) => {
     }, {});
 
     // synchronize existing issues
-    const foundIssues = await syncRepositories(repositories, Date.now() - syncLookback);
+    const foundIssues = await syncInstallations(installations, Date.now() - syncLookback);
 
     // check for all missing issues, these will
     // be automatically expired once they reach a
@@ -252,7 +299,10 @@ module.exports = async (app, config, store) => {
     log.info('start');
 
     try {
-      await doSync(repositories);
+
+      const installations = await app.getInstallations();
+
+      await doSync(installations);
 
       log.info('success');
     } catch (error) {

--- a/packages/app/lib/apps/board-api-routes.js
+++ b/packages/app/lib/apps/board-api-routes.js
@@ -167,7 +167,6 @@ module.exports = async (app, config, store) => {
 
     const {
       columns,
-      repositories,
       name
     } = config;
 
@@ -177,7 +176,7 @@ module.exports = async (app, config, store) => {
 
         return { name };
       }),
-      name: name || repositories[0] || 'empty'
+      name: name || 'Wuffle Board'
     });
 
   });

--- a/packages/app/lib/apps/installations.js
+++ b/packages/app/lib/apps/installations.js
@@ -1,0 +1,123 @@
+const PermissionLevels = {
+  read: 1,
+  write: 2,
+  none: 0
+};
+
+const RequiredPermissions = {
+  issues: 'write',
+  pull_requests: 'write',
+  contents: 'read',
+  metadata: 'read'
+};
+
+const RequiredEvents = [
+  'create',
+  'issues',
+  'issue_comment',
+  'label',
+  'milestone',
+  'pull_request',
+  'repository'
+];
+
+
+/**
+ * This component validates and exposes
+ * installations of the GitHub app.
+ *
+ * @param {Application} app
+ * @param {Object} config
+ * @param {Store} store
+ */
+module.exports = function(app, config, store) {
+
+  const log = app.log.child({
+    name: 'wuffle:installations'
+  });
+
+  /*
+  app.on([
+    'installation',
+    'installation_repositories'
+  ], async ({ payload }) => {
+
+    console.log('installation update', payload);
+  });
+  */
+
+  function isRequiredLevel(requested, actual) {
+    return PermissionLevels[requested] <= PermissionLevels[actual || 'none'];
+  }
+
+  function validateInstallation(installation) {
+
+    const {
+      account,
+      permissions,
+      events
+    } = installation;
+
+    const {
+      login
+    } = account;
+
+    const missingPermissions = Object.entries(RequiredPermissions).filter(
+      ([ permission, requestedLevel ]) => {
+        const actualLevel = permissions[permission];
+
+        return !isRequiredLevel(actualLevel, requestedLevel);
+      }
+    );
+
+    const missingEvents = RequiredEvents.filter(
+      (event) => !events.includes(event)
+    );
+
+    if (missingPermissions.length) {
+      log.warn({
+        installation: login,
+        permissions
+      }, 'missing required permissions', missingPermissions);
+    }
+
+    if (missingEvents.length) {
+      log.warn({
+        installation: login,
+        events
+      }, 'missing required event subscriptions', missingEvents);
+    }
+
+  }
+
+  function validateInstallations(installations) {
+    log.debug('validate installations');
+
+    installations.map(validateInstallation);
+
+    log.debug('validated installations');
+  }
+
+  async function fetchInstallations() {
+
+    const github = await app.auth();
+
+    return github.paginate(
+      github.apps.listInstallations.endpoint.merge({ per_page: 100 }),
+      (response) => response.data
+    );
+  }
+
+
+  // API ////////////
+
+  app.getInstallations = function() {
+    return fetchInstallations().then(installations => {
+
+      validateInstallations(installations);
+
+      return installations;
+    });
+  };
+
+};

--- a/packages/app/lib/apps/on-active.js
+++ b/packages/app/lib/apps/on-active.js
@@ -8,33 +8,10 @@
  */
 module.exports = async (app, config, store) => {
 
-  const repositoryMap = config.repositories.reduce((map, name) => {
-    map[name] = true;
-
-    return map;
-  }, {});
-
-
-  function onActive(events, fn) {
-
-    app.on(events, function(context) {
-
-      const {
-        repository
-      } = context.payload;
-
-      if (!repositoryMap[repository.full_name]) {
-        return;
-      }
-
-      return fn(context);
-    });
-
-  }
-
+  // NOTE: this is a noop, since we dropped config.repositories
 
   // api ////////////////////
 
-  app.onActive = onActive;
+  app.onActive = app.on;
 
 };

--- a/packages/app/lib/index.js
+++ b/packages/app/lib/index.js
@@ -8,6 +8,7 @@ const apps = [
       : require('./apps/dump-store')
   ),
   require('./apps/on-active'),
+  require('./apps/installations'),
   require('./apps/org-auth'),
   require('./apps/user-auth'),
   require('./apps/events-sync'),

--- a/packages/app/wuffle.config.example.js
+++ b/packages/app/wuffle.config.example.js
@@ -1,9 +1,12 @@
 /**
- * This defines all columns for the board as well as
- * repositories to be synced.
+ * This defines board specific configuration.
+ *
+ * ### Name
+ *
+ * The name of your board, displayed in the board header.
  *
  *
- * ## Columns
+ * ### Columns
  *
  * Valid fields for columns are
  *
@@ -16,13 +19,11 @@
  * The default column is the column that holds open issues without
  * any label constraints (Inbox in the example below).
  *
- *
- * ## Repositories
- *
- * Repositories must be matched by their short name {owner}/{repoName}.
- *
  */
 module.exports = {
+
+  name: 'My Wuffle Board',
+
   columns: [
     { name: 'Inbox', label: null },
     { name: 'Backlog', label: 'backlog', sorting: true },
@@ -30,6 +31,6 @@ module.exports = {
     { name: 'In Progress', label: 'in progress', sorting: true },
     { name: 'Needs Review', label: 'needs review', sorting: true },
     { name: 'Done', label: null, closed: true }
-  ],
-  repositories: []
+  ]
+
 };


### PR DESCRIPTION
GitHub gives organization administrators a high degree of control where to install a GitHub app / for which repositories to enable it.

This PR makes GitHub app installations (and thereby connected repositories) the single source of truth.

* Adding and removing installations will be reflected on the board, without restart
* `config.repositories` is now obsolete and got dropped
* Installations are validated with regards to proper required events and permissions
* Background sync does not bail out, if individual issues cannot be synchronized
* The board name is not deduced by connected repositories but must be manually chosen and configured via `config.name` in `wuffle.config.js`