### PR TITLE
Add <created> and <update> filter

### DIFF
--- a/packages/app/lib/util/index.js
+++ b/packages/app/lib/util/index.js
@@ -9,7 +9,8 @@ const {
 } = require('./links');
 
 const {
-  parseSearch
+  parseSearch,
+  parseTemporalFilter
 } = require('./search');
 
 const preExit = require('./pre-exit');
@@ -36,6 +37,7 @@ module.exports.findLinks = findLinks;
 module.exports.linkTypes = linkTypes;
 
 module.exports.parseSearch = parseSearch;
+module.exports.parseTemporalFilter = parseTemporalFilter;
 
 module.exports.repoAndOwner = repoAndOwner;
 

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -1,7 +1,37 @@
 
+function parseTemporalFilter(str) {
+
+  const regexp = /^(>|>=|<|<=)?(\d{4}-\d{1,2}-\d{1,2})$/;
+
+  const match = regexp.exec(str);
+
+  if (!match) {
+    return null;
+  }
+
+  const [
+    _, // eslint-disable-line
+    qualifier,
+    dateString
+  ] = match;
+
+  const date = Date.parse(dateString);
+
+  if (isNaN(date)) {
+    return null;
+  }
+
+  return {
+    qualifier,
+    date
+  };
+}
+
+module.exports.parseTemporalFilter = parseTemporalFilter;
+
 function parseSearch(str) {
 
-  const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w#/&-.]+)|"([\w-#/&:. ]+)")?)(?:\s|$)/g;
+  const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w-#/&<>=.]+)|"([\w-#/&:. ]+)")?)(?:\s|$)/g;
 
   const terms = [];
 

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -5,7 +5,8 @@ const {
 const {
   findLinks,
   linkTypes,
-  parseSearch
+  parseSearch,
+  parseTemporalFilter
 } = require('../lib/util');
 
 const {
@@ -733,6 +734,88 @@ describe('util', function() {
         { qualifier: 'is', value: 'open_bar', negated: false }
       ]);
 
+    });
+
+
+    it('should parse temporal filter in value', function() {
+
+      // when
+      const search = parseSearch([
+        'created:<2020-09-14',
+        'updated:>=2020-09-14'
+      ].join(' '));
+
+      // then
+      expect(search).to.eql([
+        { qualifier: 'created', value: '<2020-09-14', negated: false },
+        { qualifier: 'updated', value: '>=2020-09-14', negated: false }
+      ]);
+    });
+
+  });
+
+
+  describe('parseTemporalFilter', function() {
+
+    it('should parse greater than', function() {
+
+      // when
+      const filter = parseTemporalFilter('>2020-09-15');
+
+      // then
+      expect(filter).to.eql({
+        date: 1600128000000,
+        qualifier: '>'
+      });
+    });
+
+
+    it('should parse greater than or equal', function() {
+
+      // when
+      const filter = parseTemporalFilter('>=2020-09-15');
+
+      // then
+      expect(filter).to.eql({
+        date: 1600128000000,
+        qualifier: '>='
+      });
+    });
+
+
+    it('should parse smaller than', function() {
+
+      // when
+      const filter = parseTemporalFilter('<2020-09-15');
+
+      // then
+      expect(filter).to.eql({
+        date: 1600128000000,
+        qualifier: '<'
+      });
+    });
+
+
+    it('should parse smaller than or equal', function() {
+
+      // when
+      const filter = parseTemporalFilter('<=2020-09-15');
+
+      // then
+      expect(filter).to.eql({
+        date: 1600128000000,
+        qualifier: '<='
+      });
+    });
+
+
+    it('should ignore invalid', function() {
+
+      // when
+      const filter = parseTemporalFilter('<=2020-15');
+
+      // then
+      expect(filter).not.to.exist;
     });
 
   });

--- a/packages/board/src/BoardFilter.svelte
+++ b/packages/board/src/BoardFilter.svelte
@@ -55,6 +55,16 @@
       'pull'
     ].map(name => {
       return { name, value: `${name} ` };
+    }),
+    created: [
+      [ 'today', Date.now() ],
+      [ 'last week', Date.now() - 1000 * 60 * 60 * 24 * 7 ],
+      [ 'last month', Date.now() - 1000 * 60 * 60 * 24 * 7 * 30 ]
+    ].map(([ name, value ]) => {
+
+      const date = new Date(value);
+
+      return { name, value: `>=${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()} ` };
     })
   };
 
@@ -82,6 +92,8 @@
         'repo',
         'reviewer',
         'milestone',
+        'created',
+        'updated',
         'is'
       ].map(name => {
         return {


### PR DESCRIPTION
Adds basic support for GitHub's [created and updated filters](https://docs.github.com/en/free-pro-team@latest/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-by-when-an-issue-or-pull-request-was-created-or-last-updated).