### PR TITLE
Add involves filter

### DIFF
--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -177,6 +177,17 @@ function Search(logger, store) {
       };
     },
 
+    involves: function involvesFilter(name) {
+
+      return function filterInvolves(issue) {
+        return (
+          filters.assignee(name)(issue) ||
+          filters.author(name)(issue) ||
+          filters.reviewer(name)(issue)
+        );
+      };
+    },
+
     created: temporalFilter(function(matchTemporal) {
       return function filterCreated(issue) {
         return matchTemporal(issue.created_at);

--- a/packages/board/src/BoardFilter.svelte
+++ b/packages/board/src/BoardFilter.svelte
@@ -92,6 +92,7 @@
         'repo',
         'reviewer',
         'milestone',
+        'involves',
         'created',
         'updated',
         'is'


### PR DESCRIPTION
The [involves filter](https://docs.github.com/en/free-pro-team@latest/github/searching-for-information-on-github/searching-issues-and-pull-requests#search-by-a-user-thats-involved-in-an-issue-or-pull-request) combines existing author, reviewer and assignee filters.