### PR TITLE
Convert to draft and back again

### DIFF
--- a/docs/AUTOMATIC_CARD_MOVEMENT.md
+++ b/docs/AUTOMATIC_CARD_MOVEMENT.md
@@ -12,8 +12,9 @@ The following table summarizes triggers and the card movements those cause.
 | Trigger | Action |
 | :--- | :--- |
 | Branch with `{issueNumber}-some-description` created | Issue moves to `IN_PROGRESS` column and is assigned to branch author |
-| Draft PR referencing issue created | Issue moves to `IN_PROGRESS` column |
-| PR is marked as ready-for-review | PR and linked issue move to `IN_REVIEW` column |
-| Non-draft PR is created | PR and linked issue move to `IN_REVIEW` column |
+| Collaborator PR is created | PR and linked issue move to `IN_REVIEW` or `IN_PROGRESS` (if PR is draft) column |
+| Collaborator PR is marked as draft | PR and linked issue move to `IN_PROGRESS` column |
+| Collaborator PR is marked as ready-for-review | PR and linked issue move to `IN_REVIEW` column |
+| Collaborator PR receives `changes_requested` review | PR moves to `IN_PROGRESS` column |
 | PR is merged | PR and linked issue move to `DONE` column |
 | PR is closed unmerged | PR moves to `DONE` column, linked issue stays where it is |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -57,6 +57,12 @@ Several aspects of [wuffle](https://wuffle.dev) are configured via environment v
 | `DISABLE_BACKGROUND_SYNC` | | |
 
 
+### Behavior
+
+| Parameter | Required? | Description |
+| :--- | :---: | :--- |
+| `AUTO_ASSIGN_PULLS` | | If set, assign newly created collaborator PRs to the PR author |
+
 ### Misc
 
 | Parameter | Required? | Description |

--- a/packages/app/lib/apps/events-sync.js
+++ b/packages/app/lib/apps/events-sync.js
@@ -101,6 +101,7 @@ function EventsSync(webhookEvents, store, logger) {
     'pull_request.unlabeled',
     'pull_request.edited',
     'pull_request.ready_for_review',
+    'pull_request.converted_to_draft',
     'pull_request.assigned',
     'pull_request.unassigned',
     'pull_request.synchronize',

--- a/packages/app/test.js
+++ b/packages/app/test.js
@@ -1,0 +1,35 @@
+const gql = require('fake-tag');
+
+const { graphql } = require('@octokit/graphql');
+
+const authenticatedGraphql = graphql.defaults({
+  headers: {
+    authorization: `token ${process.env.TOKEN}`
+  }
+});
+
+const convertToDraftQuery = gql`
+  mutation ConvertToDraft($pull_id: ID!) {
+    convertPullRequestToDraft(input: { pullRequestId: $pull_id }) {
+      pullRequest {
+        updatedAt
+      }
+    }
+  }
+`;
+
+const markReadyForReviewQuery = gql`
+  mutation MarkReadyForReview($pull_id: ID!) {
+    markPullRequestReadyForReview(input: { pullRequestId: $pull_id }) {
+      pullRequest {
+        updatedAt
+      }
+    }
+  }
+`;
+
+authenticatedGraphql(markReadyForReviewQuery, {"pull_id": "MDExOlB1bGxSZXF1ZXN0MzI3NTkzNTc2" }).then(result => {
+  console.log(result);
+}).catch(err => {
+  console.error(err);
+});

--- a/packages/board/src/CollaboratorLinks.svelte
+++ b/packages/board/src/CollaboratorLinks.svelte
@@ -102,7 +102,7 @@
     margin: 0;
     font-size: 14px;
     position: relative;
-    display: inline-block;
+    display: flex;
     text-align: center;
     border-radius: 2px;
 


### PR DESCRIPTION
This ensures that PRs moved back to _in progress_ are coverted to drafts and PRs that are moved to _ready for review_ are _marked as ready_.

Closes https://github.com/nikku/wuffle/issues/116.

---

Note that this PR does not work due to GitHub App limitations for the `convertPullRequestToDraft` and `markPullRequestReadyForReview` mutations. These are currently unavailable for GitHub apps.