### PR TITLE
feat(apps/dump-store-s3): allow setting custom S3 endpoint

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,7 +41,7 @@ Several aspects of [wuffle](https://wuffle.dev) are configured via environment v
 | `S3_BUCKET` |  | Name of S3 bucket to load and dump task board to |
 | `S3_REGION` |  | Region of the S3 bucket to dump to |
 | `S3_KEY` |  | Name of the file to store in the bucket; defaults to `storedump.json` |
-| `S3_ENDPOINT` |  | fully qualified domain name of the S3 compatible service you are using to persist data with; defaults to AWS S3 endpoints |
+| `S3_ENDPOINT` |  | Fully qualified domain name of the S3 compatible endpoint to use; defaults to AWS S3 endpoints |
 
 
 ### Background Sync

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -41,6 +41,7 @@ Several aspects of [wuffle](https://wuffle.dev) are configured via environment v
 | `S3_BUCKET` |  | Name of S3 bucket to load and dump task board to |
 | `S3_REGION` |  | Region of the S3 bucket to dump to |
 | `S3_KEY` |  | Name of the file to store in the bucket; defaults to `storedump.json` |
+| `S3_ENDPOINT` |  | fully qualified domain name of the S3 compatible service you are using to persist data with; defaults to AWS S3 endpoints |
 
 
 ### Background Sync

--- a/packages/app/lib/apps/dump-store/s3/S3.js
+++ b/packages/app/lib/apps/dump-store/s3/S3.js
@@ -11,11 +11,13 @@ function S3() {
     AWS_SECRET_ACCESS_KEY: secretAccessKey,
     S3_BUCKET: bucket,
     S3_REGION: region,
-    S3_KEY: key = 'storedump.json'
+    S3_KEY: key = 'storedump.json',
+    S3_ENDPOINT: endpoint
   } = process.env;
 
   const s3client = new S3Client({
     region,
+    endpoint,
     credentials: {
       accessKeyId,
       secretAccessKey


### PR DESCRIPTION
allows using a custom s3-compatible store for persisting board data

when S3_ENDPOINT is not set, defaults to AWS-specific endpoints