### PR TITLE
Support `@me` to reference logged-in user in search

### DIFF
--- a/packages/app/lib/apps/board-api-routes/board-api-routes.js
+++ b/packages/app/lib/apps/board-api-routes/board-api-routes.js
@@ -68,7 +68,9 @@ module.exports = async (
       return null;
     }
 
-    return search.getSearchFilter(s);
+    const user = authRoutes.getGitHubUser(req);
+
+    return search.getSearchFilter(s, user);
   }
 
   function getIssueReadFilter(req) {

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -35,8 +35,16 @@ function Search(logger, store) {
     return true;
   }
 
+  function filterReject(issue) {
+    return false;
+  }
+
   function noopFilter(value) {
     return filterNoop;
+  }
+
+  function noneFilter(value) {
+    return filterReject;
   }
 
   function includes(actual, pattern) {
@@ -285,15 +293,16 @@ function Search(logger, store) {
    * Retrieve a filter function from the given search string.
    *
    * @param {string} search
+   * @param {import('../../types').GitHubUser} [user]
    *
    * @return {Function}
    */
-  function getSearchFilter(search) {
+  function getSearchFilter(search, user) {
 
     const terms = parseSearch(search);
 
     const filterFns = terms.map(term => {
-      const {
+      let {
         qualifier,
         value,
         negated
@@ -301,6 +310,14 @@ function Search(logger, store) {
 
       if (!value) {
         return noopFilter();
+      }
+
+      if (value === '@me') {
+        if (!user) {
+          return noneFilter();
+        }
+
+        value = user.login;
       }
 
       const factoryFn = filters[qualifier];


### PR DESCRIPTION
Support mentioning `@me` to reference logged-in user in search.

