### PR TITLE
fix(search): allow comma in quoted text

### DIFF
--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -59,7 +59,7 @@ function startOfDay(time) {
 
 function parseSearch(str) {
 
-  const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w-#/&@<>=.]+)|"([\w-#/&@:. ]+)")?)(?:\s|$)/g;
+  const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w-#/&@<>=.]+)|"([\w-#/&@:.,; ]+)")?)(?:\s|$)/g;
 
   const terms = [];
 

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -623,7 +623,8 @@ describe('util', function() {
         'author:walt',
         'label:"in progress"',
         'ref:foo/bar#80',
-        'assignee:@me'
+        'assignee:@me',
+        'label:"some,stuff;yea"'
       ].join(' ');
 
       // when
@@ -641,7 +642,8 @@ describe('util', function() {
         { qualifier: 'author', value: 'walt', negated: false },
         { qualifier: 'label', value: 'in progress', negated: false },
         { qualifier: 'ref', value: 'foo/bar#80', negated: false },
-        { qualifier: 'assignee', value: '@me', negated: false }
+        { qualifier: 'assignee', value: '@me', negated: false },
+        { qualifier: 'label', value: 'some,stuff;yea', negated: false }
       ]);
 
     });


### PR DESCRIPTION
Allows `,;` to appear in quoted search.