### PR TITLE
fix(board): prevent double committing search suggestion

### DIFF
--- a/packages/board/src/components/HintList.svelte
+++ b/packages/board/src/components/HintList.svelte
@@ -83,7 +83,7 @@
 </style>
 
 <ul class={ [ className, 'hint-list', 'scroll-container-v' ].join(' ') }>
-  {#each hints as hint, idx}
+  {#each hints as hint(hint.name) }
     <li
       use:scrollIntoView={ [ hint, selectedHint ] }
     >


### PR DESCRIPTION
Without proper keying we'd handle mousedown twice.