### PR TITLE
feat: add OR filter

### DIFF
--- a/docs/BOARD_FILTERS.md
+++ b/docs/BOARD_FILTERS.md
@@ -17,7 +17,13 @@ The board supports the following filters:
 | `label` | Filter by [label](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels) | `label:critical` |
 | `repo` | Filter by repository | `repo:"nikku/wuffle"` |
 
-Filters get chained together by the board with _and_ semantics.
+Filters get chained together by the board with _and_ semantics. Use the `OR` keyword to combine groups with _or_ semantics:
+
+```
+repo:foo/bar label:bug OR -repo:baz/qux
+```
+
+This matches issues that either belong to `foo/bar` with label `bug`, or do not belong to `baz/qux`. Within each group, filters are combined with _and_. Between groups, it is _or_.
 
 
 ## Applying Filters

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -318,47 +318,65 @@ export default function Search(config, logger, store) {
     };
   }
 
-  function buildFilterFns(search, user) {
+  /**
+   * Build a filter function for a given search term.
+   *
+   * @param {import('../../util/search.js').SearchTerm} term
+   * @param {import('../../types.js').GitHubUser} [user]
+   * @returns {Function}
+   */
+  function buildTermFilterFn(term, user) {
+    let {
+      qualifier,
+      value,
+      negated,
+      exact
+    } = term;
 
-    const terms = search ? parseSearch(search) : [];
+    if (!value) {
+      return noopFilter();
+    }
 
-    return terms.map(term => {
-      let {
-        qualifier,
-        value,
-        negated,
-        exact
-      } = term;
-
-      if (!value) {
-        return noopFilter();
+    if (value === '@me') {
+      if (!user) {
+        return noneFilter();
       }
 
-      if (value === '@me') {
-        if (!user) {
-          return noneFilter();
-        }
+      value = user.login;
+      exact = true;
+    }
 
-        value = user.login;
-        exact = true;
-      }
+    const factoryFn = filters[qualifier];
 
-      const factoryFn = filters[qualifier];
+    if (!factoryFn) {
+      return noopFilter();
+    }
 
-      if (!factoryFn) {
-        return noopFilter();
-      }
+    const fn = factoryFn(value, exact);
 
-      const fn = factoryFn(value, exact);
+    if (negated) {
+      return function(arg) {
+        return !fn(arg);
+      };
+    }
 
-      if (negated) {
-        return function(arg) {
-          return !fn(arg);
-        };
-      }
+    return fn;
+  }
 
-      return fn;
-    });
+  /**
+   * Build filter functions for each group of search terms.
+   *
+   * @param {string} search
+   * @param {import('../../types.js').GitHubUser} [user]
+   * @returns {Function[][]}
+   */
+  function buildFilterGroups(search, user) {
+
+    const groups = search ? parseSearch(search) : [];
+
+    return groups.map(
+      terms => terms.map(term => buildTermFilterFn(term, user))
+    );
   }
 
   /**
@@ -371,17 +389,21 @@ export default function Search(config, logger, store) {
    */
   function getSearchFilter(search, user) {
 
-    const filterFns = buildFilterFns(search, user);
+    const filterGroups = buildFilterGroups(search, user);
 
-    const ignoreFilterFns = buildFilterFns(config.defaultFilter, user);
+    const ignoreFilterGroups = buildFilterGroups(config.defaultFilter, user);
 
     return function(issue) {
       try {
-        if (filterFns.length) {
-          return filterFns.every(fn => fn(issue));
+        if (filterGroups.some(group => group.length > 0)) {
+          return filterGroups.some(
+            group => group.every(fn => fn(issue))
+          );
         } else {
 
-          return ignoreFilterFns.every(fn => fn(issue));
+          return ignoreFilterGroups.some(
+            group => group.every(fn => fn(issue))
+          );
         }
       } catch (err) {
         log.warn({ issue: issueIdent(issue), err }, 'filter failed');

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -55,24 +55,32 @@ function startOfDay(time) {
 }
 
 /**
- * @param {string} str
- *
- * @return { {
+ * @typedef { {
  *   qualifier: string,
  *   value: string|undefined,
  *   exact: boolean,
  *   negated?: boolean
- * }[] }
+ * } } SearchTerm
+ */
+
+/**
+ * @typedef {SearchTerm[]} SearchGroup
+ */
+
+/**
+ * @param {string} str
+ *
+ * @return {SearchGroup[]}
  */
 export function parseSearch(str) {
 
   const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w-#/&@<>=.]+)|"([\w-#/&@:.,; ]+)")?)(?:\s|$)/g;
 
-  const terms = [];
+  const groups = [ [] ];
 
   let match;
 
-  while ((match = regexp.exec(str))) {
+  while ((match = regexp.exec(str || ''))) {
 
     const [
       _,
@@ -84,11 +92,15 @@ export function parseSearch(str) {
       qualifierTextEscaped
     ] = match;
 
-
     const textValue = text || textEscaped;
 
+    if (textValue === 'OR' && !textEscaped) {
+      groups.push([]);
+      continue;
+    }
+
     if (textValue) {
-      terms.push({
+      groups[groups.length - 1].push({
         qualifier: 'text',
         value: textValue,
         exact: !!textEscaped
@@ -98,7 +110,7 @@ export function parseSearch(str) {
     const qualifierValue = qualifierText || qualifierTextEscaped;
 
     if (qualifier) {
-      terms.push({
+      groups[groups.length - 1].push({
         qualifier,
         value: qualifierValue,
         negated: !!negated,
@@ -107,5 +119,5 @@ export function parseSearch(str) {
     }
   }
 
-  return terms;
+  return groups;
 }

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -688,18 +688,20 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'text', value: 'Copy& Paste', exact: true },
-        { qualifier: 'is', value: 'open', negated: false, exact: false },
-        { qualifier: 'text', value: 'asdsad', exact: false },
-        { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
-        { qualifier: 'text', value: 'FOO BAR', exact: true },
-        { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
-        { qualifier: 'milestone', value: undefined, negated: false, exact: false },
-        { qualifier: 'author', value: 'walt', negated: false, exact: false },
-        { qualifier: 'label', value: 'in progress', negated: false, exact: true },
-        { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
-        { qualifier: 'assignee', value: '@me', negated: false, exact: false },
-        { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
+        [
+          { qualifier: 'text', value: 'Copy& Paste', exact: true },
+          { qualifier: 'is', value: 'open', negated: false, exact: false },
+          { qualifier: 'text', value: 'asdsad', exact: false },
+          { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
+          { qualifier: 'text', value: 'FOO BAR', exact: true },
+          { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
+          { qualifier: 'milestone', value: undefined, negated: false, exact: false },
+          { qualifier: 'author', value: 'walt', negated: false, exact: false },
+          { qualifier: 'label', value: 'in progress', negated: false, exact: true },
+          { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
+          { qualifier: 'assignee', value: '@me', negated: false, exact: false },
+          { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
+        ]
       ]);
 
     });
@@ -712,7 +714,9 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'is', value: 'open:b', negated: false, exact: true }
+        [
+          { qualifier: 'is', value: 'open:b', negated: false, exact: true }
+        ]
       ]);
 
     });
@@ -729,9 +733,11 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'is', value: 'open:b', negated: true, exact: true },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false }
+        [
+          { qualifier: 'is', value: 'open:b', negated: true, exact: true },
+          { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+          { qualifier: 'is', value: 'FOO', negated: true, exact: false }
+        ]
       ]);
 
     });
@@ -747,8 +753,10 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'is', value: 'open-bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open-bar', negated: false, exact: true }
+        [
+          { qualifier: 'is', value: 'open-bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open-bar', negated: false, exact: true }
+        ]
       ]);
 
     });
@@ -764,8 +772,10 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'is', value: 'open.bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open.bar', negated: false, exact: true }
+        [
+          { qualifier: 'is', value: 'open.bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open.bar', negated: false, exact: true }
+        ]
       ]);
 
     });
@@ -781,8 +791,10 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'is', value: 'open_bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open_bar', negated: false, exact: true }
+        [
+          { qualifier: 'is', value: 'open_bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open_bar', negated: false, exact: true }
+        ]
       ]);
 
     });
@@ -798,8 +810,79 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'created', value: '<2020-09-14', negated: false, exact: false },
-        { qualifier: 'updated', value: '>=2020-09-14', negated: false, exact: false }
+        [
+          { qualifier: 'created', value: '<2020-09-14', negated: false, exact: false },
+          { qualifier: 'updated', value: '>=2020-09-14', negated: false, exact: false }
+        ]
+      ]);
+    });
+
+
+    it('should parse OR groups', function() {
+
+      // when
+      const search = parseSearch('repo:foo/bar label:bug OR -repo:baz/qux');
+
+      // then
+      expect(search).to.eql([
+        [
+          { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
+          { qualifier: 'label', value: 'bug', negated: false, exact: false }
+        ],
+        [
+          { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
+        ]
+      ]);
+    });
+
+
+    it('should parse multiple OR groups', function() {
+
+      // when
+      const search = parseSearch('label:bug OR label:feature OR is:closed');
+
+      // then
+      expect(search).to.eql([
+        [
+          { qualifier: 'label', value: 'bug', negated: false, exact: false }
+        ],
+        [
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ],
+        [
+          { qualifier: 'is', value: 'closed', negated: false, exact: false }
+        ]
+      ]);
+    });
+
+
+    it('should NOT parse as OR groups if enclosed in quotes', function() {
+
+      // when
+      const search = parseSearch('"FOO OR BAR" label:feature');
+
+      // then
+      expect(search).to.eql([
+        [
+          { qualifier: 'text', value: 'FOO OR BAR', exact: true },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]
+      ]);
+    });
+
+
+    it('should not split on lowercase or', function() {
+
+      // when
+      const search = parseSearch('label:bug or label:feature');
+
+      // then
+      expect(search).to.eql([
+        [
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          { qualifier: 'text', value: 'or', exact: false },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]
       ]);
     });
 

--- a/packages/board/src/BoardFilter.svelte
+++ b/packages/board/src/BoardFilter.svelte
@@ -396,7 +396,7 @@
       </p>
 
       <p class="note">
-        Use additional operator such as <code>created</code>, <code>updated</code>, <code>milestone</code>, <code>repo</code>, <code>assignee</code>, <code>label</code> and <code>is</code> to refine your search.
+        Use additional operator such as <code>created</code>, <code>updated</code>, <code>milestone</code>, <code>repo</code>, <code>assignee</code>, <code>label</code> and <code>is</code> to refine your search. Use <code>OR</code> to combine filter groups.
       </p>
     </div>
   {/if}


### PR DESCRIPTION
This allows to divide the filter into groups with "OR" semantics. As a result, it's possible to select issues from a specific repo with a desired label next to the negated filter for other repos.

The solution follows GH code search syntax: https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax#using-boolean-operations. 

### Which issue does this PR address?

Related to https://github.com/bpmn-io/internal-docs/issues/1281
