### PR TITLE
Support grouping, `AND`, `OR` and `NOT` filters

### DIFF
--- a/docs/BOARD_FILTERS.md
+++ b/docs/BOARD_FILTERS.md
@@ -17,8 +17,25 @@ The board supports the following filters:
 | `label` | Filter by [label](https://docs.github.com/en/github/managing-your-work-on-github/managing-labels) | `label:critical` |
 | `repo` | Filter by repository | `repo:"nikku/wuffle"` |
 
-Filters get chained together by the board with _and_ semantics.
+### Using Boolean Operations
 
+Per default, filters get chained together by the board with _and_ semantics. To change this use the operators `AND`, `OR`, and `NOT` to combine search terms.
+
+As an example, use the `OR` keyword to combine groups with _or_ semantics:
+
+```
+repo:foo/bar label:bug OR repo:baz/qux
+```
+
+This matches issues that either belong to repository `foo/bar` with label `bug`, or to repository `baz/qux`.
+
+In addition, you can use `()` to group searches:
+
+```
+(is:closed OR label:bug) AND repo:foo/bar
+```
+
+This matches issues that belong to the repository `foo/bar` that are either closed or have the label `bug`.
 
 ## Applying Filters
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16967,9 +16967,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.4.tgz",
-      "integrity": "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ==",
+      "version": "5.55.5",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
+      "integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18209,7 +18209,7 @@
         "rollup-plugin-string": "^3.0.0",
         "rollup-plugin-svelte": "^7.2.3",
         "sass": "^1.77.4",
-        "svelte": "^5.55.4",
+        "svelte": "^5.55.5",
         "svelte-preprocess": "^6.0.3"
       },
       "engines": {

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -9,6 +9,11 @@ const CHILD_LINK_TYPES = {
 
 /**
  * @typedef { { defaultFilter?: string } } SearchConfig
+ * @typedef { import('../../util/search.js').SearchTerm } SearchTerm
+ *
+ * @typedef { import('../../types.js').GitHubUser } GitHubUser
+ *
+ * @typedef { (issue: any) => boolean } FilterFn
  */
 
 /**
@@ -318,71 +323,95 @@ export default function Search(config, logger, store) {
     };
   }
 
-  function buildFilterFns(search, user) {
+  /**
+   * @param {SearchTerm} term
+   * @param {any} user
+   *
+   * @return {FilterFn}
+   */
+  function buildTermFn(term, user) {
+    let {
+      qualifier,
+      value,
+      negated,
+      exact
+    } = term;
 
-    const terms = search ? parseSearch(search) : [];
+    const wrap = (fn) => negated ? ((issue) => !fn(issue)) : fn;
 
-    return terms.map(term => {
-      let {
-        qualifier,
-        value,
-        negated,
-        exact
-      } = term;
+    if ([ 'or', 'and' ].includes(qualifier)) {
 
-      if (!value) {
-        return noopFilter();
+      const childTerms = /** @type {SearchTerm[]} */ (value);
+
+      const filterFns = childTerms.map(childTerm => buildTermFn(childTerm, user));
+
+      return wrap(
+        (issue) => filterFns[qualifier === 'or' ? 'some' : 'every'](
+          filterFn => filterFn(issue)
+        )
+      );
+    }
+
+    if (!value) {
+      return noopFilter();
+    }
+
+    if (value === '@me') {
+      if (!user) {
+        return noneFilter();
       }
 
-      if (value === '@me') {
-        if (!user) {
-          return noneFilter();
-        }
+      value = user.login;
+      exact = true;
+    }
 
-        value = user.login;
-        exact = true;
-      }
+    const factoryFn = filters[qualifier];
 
-      const factoryFn = filters[qualifier];
+    if (!factoryFn) {
+      return noopFilter();
+    }
 
-      if (!factoryFn) {
-        return noopFilter();
-      }
+    return wrap(factoryFn(value, exact));
+  }
 
-      const fn = factoryFn(value, exact);
+  function buildFilterFn(search, user) {
 
-      if (negated) {
-        return function(arg) {
-          return !fn(arg);
-        };
-      }
+    const term = search && parseSearch(search);
 
-      return fn;
-    });
+    if (!term) {
+      return null;
+    }
+
+    return buildTermFn(term);
   }
 
   /**
    * Retrieve a filter function from the given search string.
    *
    * @param {string} search
-   * @param {import('../../types.js').GitHubUser} [user]
+   * @param {GitHubUser} [user]
    *
-   * @return {Function}
+   * @return {FilterFn}
    */
   function getSearchFilter(search, user) {
 
-    const filterFns = buildFilterFns(search, user);
+    const filterFn = buildFilterFn(search, user);
 
-    const ignoreFilterFns = buildFilterFns(config.defaultFilter, user);
+    const ignoreFilterFn = buildFilterFn(config.defaultFilter, user);
 
     return function(issue) {
       try {
-        if (filterFns.length) {
-          return filterFns.every(fn => fn(issue));
-        } else {
-
-          return ignoreFilterFns.every(fn => fn(issue));
+        if (filterFn) {
+          return filterFn(issue);
         }
+
+        if (ignoreFilterFn) {
+          return ignoreFilterFn(issue);
+        }
+
+        // no user search, no ignore filter,
+        // show all issues
+        return true;
       } catch (err) {
         log.warn({ issue: issueIdent(issue), err }, 'filter failed');
 

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -70,7 +70,7 @@ function startOfDay(time) {
  */
 export function parseSearch(str) {
 
-  const regexp = /([-!])?(?:"([^"]+)"|([\w#/&]+)(?:(:)(?:([\w-#/&@<>=.]+)|"([^"]+)")?)?)/g;
+  const regexp = /([-!]|NOT\s+)?(?:"([^"]+)"|([\w#/&]+)(?:(:)(?:([\w-#/&@<>=.]+)|"([^"]+)")?)?)/g;
 
   const terms = [];
 
@@ -102,7 +102,8 @@ export function parseSearch(str) {
       terms.push({
         qualifier: 'text',
         value: textValue,
-        exact: !!textEscaped
+        exact: !!textEscaped,
+        negated: !!negated
       });
     }
   }

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -70,16 +70,25 @@ function startOfDay(time) {
  */
 export function parseSearch(str) {
 
-  const regexp = /([-!]|NOT\s+)?(?:"([^"]+)"|([\w#/&]+)(?:(:)(?:([\w-#/&@<>=.]+)|"([^"]+)")?)?)/g;
+  const regexp = /(\()|(\))|(OR)\s*|(AND)\s|([-!]|NOT\s+)?(?:"([^"]+)"|([\w#/&]+)(?:(:)(?:([\w-#/&@<>=.]+)|"([^"]+)")?)?)/g;
 
-  const terms = [];
+  const stack = [ {
+    qualifier: 'and',
+    value: []
+  } ];
 
   let match;
 
   while ((match = regexp.exec(str))) {
 
+    const term = stack[stack.length - 1];
+
     const [
       _,
+      openGroup,
+      closeGroup,
+      or,
+      and,
       negated,
       textEscaped,
       text,
@@ -88,18 +97,74 @@ export function parseSearch(str) {
       qualifierTextEscaped
     ] = match;
 
+    if (openGroup) {
+      const groupTerm = {
+        qualifier: 'and',
+        value: [],
+        group: true
+      };
+
+      stack.push(groupTerm);
+      term.value.push(groupTerm);
+
+      continue;
+    }
+
+    if (closeGroup) {
+
+      let lastTerm;
+
+      do {
+        lastTerm = stack.pop();
+      } while (!lastTerm.group);
+
+      continue;
+    }
+
+    if (and) {
+
+      // default semantics
+      continue;
+    }
+
+    if (or) {
+      const nextTerm = {
+        qualifier: 'and',
+        value: []
+      };
+
+      const groupTerm = {
+        qualifier: 'or',
+        value: [
+          {
+            qualifier: 'and',
+            value: term.value.slice()
+          },
+          nextTerm
+        ]
+      };
+
+      // replace existing terms with <OR> term
+      term.value.length = 0;
+      term.value.push(groupTerm);
+
+      stack.push(nextTerm);
+
+      continue;
+    }
+
     const textValue = text || textEscaped;
     const qualifierValue = qualifierText || qualifierTextEscaped;
 
     if (qualifier) {
-      terms.push({
+      term.value.push({
         qualifier: textValue,
         value: qualifierValue,
         negated: !!negated,
         exact: !!qualifierTextEscaped
       });
     } else {
-      terms.push({
+      term.value.push({
         qualifier: 'text',
         value: textValue,
         exact: !!textEscaped,
@@ -108,5 +173,5 @@ export function parseSearch(str) {
     }
   }
 
-  return terms;
+  return stack[0].value;
 }

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -66,7 +66,7 @@ function startOfDay(time) {
 /**
  * @param {string} str
  *
- * @return {SearchTerm[]}
+ * @return {SearchTerm}
  */
 export function parseSearch(str) {
 
@@ -74,7 +74,7 @@ export function parseSearch(str) {
 
   const stack = [ {
     qualifier: 'and',
-    value: []
+    value: /** @type {SearchTerm[]} */ ([])
   } ];
 
   let match;
@@ -173,5 +173,30 @@ export function parseSearch(str) {
     }
   }
 
-  return stack[0].value;
+  return collapseSearch(stack[0]);
+}
+
+/**
+ * @param {SearchTerm} term
+ *
+ * @return {SearchTerm}
+ */
+export function collapseSearch(term) {
+
+  if (![ 'and', 'or' ].includes(term.qualifier)) {
+    return term;
+  }
+
+  const nestedTerms = /** @type {SearchTerm[]} */ (term.value);
+
+  const nestedTermsCollapsed = nestedTerms.map(collapseSearch);
+
+  if (term.qualifier === 'and' && nestedTermsCollapsed.length === 1) {
+    return nestedTermsCollapsed[0];
+  }
+
+  return {
+    ...term,
+    value: nestedTermsCollapsed
+  };
 }

--- a/packages/app/lib/util/search.js
+++ b/packages/app/lib/util/search.js
@@ -55,18 +55,22 @@ function startOfDay(time) {
 }
 
 /**
+ * @typedef { {
+ *   qualifier: string,
+ *   exact?: boolean,
+ *   negated?: boolean,
+ *   value?: string|SearchTerm[],
+ * } } SearchTerm
+ */
+
+/**
  * @param {string} str
  *
- * @return { {
- *   qualifier: string,
- *   value: string|undefined,
- *   exact: boolean,
- *   negated?: boolean
- * }[] }
+ * @return {SearchTerm[]}
  */
 export function parseSearch(str) {
 
-  const regexp = /(?:([\w#/&]+)|"([\w#/&\s-.]+)"|([-!]?)([\w]+):(?:([\w-#/&@<>=.]+)|"([\w-#/&@:.,; ]+)")?)(?:\s|$)/g;
+  const regexp = /([-!])?(?:"([^"]+)"|([\w#/&]+)(?:(:)(?:([\w-#/&@<>=.]+)|"([^"]+)")?)?)/g;
 
   const terms = [];
 
@@ -76,33 +80,29 @@ export function parseSearch(str) {
 
     const [
       _,
-      text,
-      textEscaped,
       negated,
+      textEscaped,
+      text,
       qualifier,
       qualifierText,
       qualifierTextEscaped
     ] = match;
 
-
     const textValue = text || textEscaped;
-
-    if (textValue) {
-      terms.push({
-        qualifier: 'text',
-        value: textValue,
-        exact: !!textEscaped
-      });
-    }
-
     const qualifierValue = qualifierText || qualifierTextEscaped;
 
     if (qualifier) {
       terms.push({
-        qualifier,
+        qualifier: textValue,
         value: qualifierValue,
         negated: !!negated,
         exact: !!qualifierTextEscaped
+      });
+    } else {
+      terms.push({
+        qualifier: 'text',
+        value: textValue,
+        exact: !!textEscaped
       });
     }
   }

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -666,41 +666,77 @@ describe('util', function() {
 
   describe('parseSearch', function() {
 
-    it('should parse terms', function() {
+    describe('should parse terms', function() {
 
-      const searchString = [
-        '"Copy& Paste"',
-        'is:open',
-        'asdsad',
-        'milestone:"FOO BAR"',
-        '"FOO BAR"',
-        'milestone:12asd',
-        'milestone:',
-        'author:walt',
-        'label:"in progress"',
-        'ref:foo/bar#80',
-        'assignee:@me',
-        'label:"some,stuff;yea"'
-      ].join(' ');
+      it('simple', function() {
 
-      // when
-      const search = parseSearch(searchString);
+        // given
+        const searchString = [
+          'is:open',
+          'asdsad',
+          'author:walt',
+          'ref:foo/bar#80',
+          'assignee:@me',
+        ].join(' ');
 
-      // then
-      expect(search).to.eql([
-        { qualifier: 'text', value: 'Copy& Paste', negated: false, exact: true },
-        { qualifier: 'is', value: 'open', negated: false, exact: false },
-        { qualifier: 'text', value: 'asdsad', negated: false, exact: false },
-        { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
-        { qualifier: 'text', value: 'FOO BAR', negated: false, exact: true },
-        { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
-        { qualifier: 'milestone', value: undefined, negated: false, exact: false },
-        { qualifier: 'author', value: 'walt', negated: false, exact: false },
-        { qualifier: 'label', value: 'in progress', negated: false, exact: true },
-        { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
-        { qualifier: 'assignee', value: '@me', negated: false, exact: false },
-        { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
-      ]);
+        // when
+        const search = parseSearch(searchString);
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'is', value: 'open', negated: false, exact: false },
+          { qualifier: 'text', value: 'asdsad', negated: false, exact: false },
+          { qualifier: 'author', value: 'walt', negated: false, exact: false },
+          { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
+          { qualifier: 'assignee', value: '@me', negated: false, exact: false }
+        ]);
+
+      });
+
+
+      it('escaped / exact', function() {
+
+        // given
+        const searchString = [
+          '"Copy& Paste"',
+          'milestone:"FOO BAR"',
+          '"FOO BAR"',
+          'milestone:12asd',
+          'label:"in progress"',
+          'label:"some,stuff;yea"'
+        ].join(' ');
+
+        // when
+        const search = parseSearch(searchString);
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'text', value: 'Copy& Paste', negated: false, exact: true },
+          { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
+          { qualifier: 'text', value: 'FOO BAR', negated: false, exact: true },
+          { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
+          { qualifier: 'label', value: 'in progress', negated: false, exact: true },
+          { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
+        ]);
+
+      });
+
+
+      it('partial', function() {
+
+        // given
+        const searchString = [
+          'milestone:'
+        ].join(' ');
+
+        // when
+        const search = parseSearch(searchString);
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'milestone', value: undefined, negated: false, exact: false }
+        ]);
+      });
 
     });
 

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -1017,6 +1017,26 @@ describe('util', function() {
     });
 
 
+    it('should parse AND over OR', function() {
+
+      const search = parseSearch('foo bar OR woop');
+
+      expect(search).to.eql({
+        qualifier: 'or',
+        value: [
+          {
+            qualifier: 'and',
+            value: [
+              { qualifier: 'text', value: 'foo', negated: false, exact: false },
+              { qualifier: 'text', value: 'bar', negated: false, exact: false }
+            ]
+          },
+          { qualifier: 'text', value: 'woop', negated: false, exact: false },
+        ]
+      });
+    });
+
+
     it('should parse mixed AND + OR', function() {
 
       // when

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -849,6 +849,347 @@ describe('util', function() {
       ]);
     });
 
+
+    describe('OR groups', function() {
+
+      it('should parse', function() {
+
+        // when
+        const search = parseSearch('repo:foo/bar label:bug OR -repo:baz/qux');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'or',
+            value: [
+              {
+                qualifier: 'and',
+                value: [
+                  { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
+                  { qualifier: 'label', value: 'bug', negated: false, exact: false }
+                ]
+              },
+              {
+                qualifier: 'and',
+                value: [
+                  { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
+                ]
+              }
+            ]
+          }
+        ]);
+      });
+
+
+      it('should parse multiple', function() {
+
+        // when
+        const search = parseSearch('label:bug OR label:feature OR is:closed');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'or',
+            value: [
+              {
+                qualifier: 'and',
+                value: [
+                  { qualifier: 'label', value: 'bug', negated: false, exact: false }
+                ]
+              },
+              {
+                qualifier: 'and',
+                value: [
+                  {
+                    qualifier: 'or',
+                    value: [
+                      {
+                        qualifier: 'and',
+                        value: [
+                          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+                        ]
+                      },
+                      {
+                        qualifier: 'and',
+                        value: [
+                          { qualifier: 'is', value: 'closed', negated: false, exact: false }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]);
+      });
+
+
+      it('should NOT parse enclosed in quotes', function() {
+
+        // when
+        const search = parseSearch('"FOO OR BAR" label:feature');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'text', value: 'FOO OR BAR', negated: false, exact: true },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]);
+      });
+
+
+      it('should NOT parse lowercase or', function() {
+
+        // when
+        const search = parseSearch('label:bug or label:feature');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          { qualifier: 'text', value: 'or', negated: false, exact: false },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]);
+      });
+
+    });
+
+
+    describe('AND groups', function() {
+
+      it('should parse', function() {
+
+        // when
+        const search = parseSearch('repo:foo/bar label:bug AND -repo:baz/qux');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
+        ]);
+      });
+
+
+      it('should parse multiple', function() {
+
+        // when
+        const search = parseSearch('label:bug AND label:feature AND is:closed');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false },
+          { qualifier: 'is', value: 'closed', negated: false, exact: false }
+        ]);
+      });
+
+
+      it('should NOT parse enclosed in quotes', function() {
+
+        // when
+        const search = parseSearch('"FOO AND BAR" label:feature');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'text', value: 'FOO AND BAR', negated: false, exact: true },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]);
+      });
+
+
+      it('should not parse lowercase and', function() {
+
+        // when
+        const search = parseSearch('label:bug and label:feature');
+
+        // then
+        expect(search).to.eql([
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          { qualifier: 'text', value: 'and', negated: false, exact: false },
+          { qualifier: 'label', value: 'feature', negated: false, exact: false }
+        ]);
+      });
+
+    });
+
+
+    it('should parse mixed AND + OR', function() {
+
+      // when
+      const search = parseSearch('label:bug OR label:feature AND "bug" OR "other"');
+
+      // then
+      // parsed as ( label:bug OR ( (label:feature AND "bug") OR "other" ) )
+      expect(search).to.eql([
+        {
+          qualifier: 'or',
+          value: [
+            {
+              qualifier: 'and',
+              value: [
+                { qualifier: 'label', value: 'bug', negated: false, exact: false }
+              ]
+            },
+            {
+              qualifier: 'and',
+              value: [
+                {
+                  qualifier: 'or',
+                  value: [
+                    {
+                      qualifier: 'and',
+                      value: [
+                        { qualifier: 'label', value: 'feature', negated: false, exact: false },
+                        { qualifier: 'text', value: 'bug', exact: true, negated: false }
+                      ]
+                    },
+                    {
+                      qualifier: 'and',
+                      value: [
+                        { qualifier: 'text', value: 'other', exact: true, negated: false }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]);
+    });
+
+
+    describe('grouped', function() {
+
+      it('should parse simple', function() {
+
+        // when
+        const search = parseSearch('(label:feature)');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'and',
+            group: true,
+            value: [
+              { exact: false, negated: false, qualifier: 'label', value: 'feature' }
+            ]
+          }
+        ]);
+      });
+
+
+      it('should parse AND joined', function() {
+
+        // when
+        const search = parseSearch('(a b)');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'and',
+            group: true,
+            value: [
+              { exact: false, negated: false, qualifier: 'text', value: 'a' },
+              { exact: false, negated: false, qualifier: 'text', value: 'b' }
+            ]
+          }
+        ]);
+      });
+
+
+      it('should parse OR joined', function() {
+
+        // when
+        const search = parseSearch('(a OR b)');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'and',
+            group: true,
+            value: [
+              {
+                qualifier: 'or',
+                value: [
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { exact: false, negated: false, qualifier: 'text', value: 'a' }
+                    ]
+                  },
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { exact: false, negated: false, qualifier: 'text', value: 'b' }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]);
+      });
+
+
+      it('should parse complex', function() {
+
+        // when
+        const search = parseSearch('(label:bug OR label:feature) AND ("bug" OR "other")');
+
+        // then
+        expect(search).to.eql([
+          {
+            qualifier: 'and',
+            group: true,
+            value: [
+              {
+                qualifier: 'or',
+                value: [
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { qualifier: 'label', value: 'bug', negated: false, exact: false }
+                    ]
+                  },
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { qualifier: 'label', value: 'feature', negated: false, exact: false }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            qualifier: 'and',
+            group: true,
+            value: [
+              {
+                qualifier: 'or',
+                value: [
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { qualifier: 'text', value: 'bug', exact: true, negated: false }
+                    ]
+                  },
+                  {
+                    qualifier: 'and',
+                    value: [
+                      { qualifier: 'text', value: 'other', exact: true, negated: false }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]);
+      });
+
+    });
+
   });
 
 

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -683,14 +683,16 @@ describe('util', function() {
         const search = parseSearch(searchString);
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'is', value: 'open', negated: false, exact: false },
-          { qualifier: 'text', value: 'asdsad', negated: false, exact: false },
-          { qualifier: 'author', value: 'walt', negated: false, exact: false },
-          { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
-          { qualifier: 'assignee', value: '@me', negated: false, exact: false }
-        ]);
-
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'is', value: 'open', negated: false, exact: false },
+            { qualifier: 'text', value: 'asdsad', negated: false, exact: false },
+            { qualifier: 'author', value: 'walt', negated: false, exact: false },
+            { qualifier: 'ref', value: 'foo/bar#80', negated: false, exact: false },
+            { qualifier: 'assignee', value: '@me', negated: false, exact: false }
+          ]
+        });
       });
 
 
@@ -710,15 +712,17 @@ describe('util', function() {
         const search = parseSearch(searchString);
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'text', value: 'Copy& Paste', negated: false, exact: true },
-          { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
-          { qualifier: 'text', value: 'FOO BAR', negated: false, exact: true },
-          { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
-          { qualifier: 'label', value: 'in progress', negated: false, exact: true },
-          { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
-        ]);
-
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'text', value: 'Copy& Paste', negated: false, exact: true },
+            { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
+            { qualifier: 'text', value: 'FOO BAR', negated: false, exact: true },
+            { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
+            { qualifier: 'label', value: 'in progress', negated: false, exact: true },
+            { qualifier: 'label', value: 'some,stuff;yea', negated: false, exact: true }
+          ]
+        });
       });
 
 
@@ -733,9 +737,9 @@ describe('util', function() {
         const search = parseSearch(searchString);
 
         // then
-        expect(search).to.eql([
+        expect(search).to.eql(
           { qualifier: 'milestone', value: undefined, negated: false, exact: false }
-        ]);
+        );
       });
 
     });
@@ -747,9 +751,9 @@ describe('util', function() {
       const search = parseSearch('is:"open:b"');
 
       // then
-      expect(search).to.eql([
+      expect(search).to.eql(
         { qualifier: 'is', value: 'open:b', negated: false, exact: true }
-      ]);
+      );
 
     });
 
@@ -769,17 +773,19 @@ describe('util', function() {
       ].join(' '));
 
       // then
-      expect(search).to.eql([
-        { qualifier: 'is', value: 'open:b', negated: true, exact: true },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'text', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'text', value: 'FOO', negated: true, exact: true },
-        { qualifier: 'text', value: 'NOTARIZED', negated: true, exact: false },
-        { qualifier: 'text', value: 'NOTARIZED', negated: false, exact: false }
-      ]);
-
+      expect(search).to.eql({
+        qualifier: 'and',
+        value: [
+          { qualifier: 'is', value: 'open:b', negated: true, exact: true },
+          { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+          { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+          { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+          { qualifier: 'text', value: 'FOO', negated: true, exact: false },
+          { qualifier: 'text', value: 'FOO', negated: true, exact: true },
+          { qualifier: 'text', value: 'NOTARIZED', negated: true, exact: false },
+          { qualifier: 'text', value: 'NOTARIZED', negated: false, exact: false }
+        ]
+      });
     });
 
 
@@ -792,11 +798,13 @@ describe('util', function() {
       ].join(' '));
 
       // then
-      expect(search).to.eql([
-        { qualifier: 'is', value: 'open-bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open-bar', negated: false, exact: true }
-      ]);
-
+      expect(search).to.eql({
+        qualifier: 'and',
+        value: [
+          { qualifier: 'is', value: 'open-bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open-bar', negated: false, exact: true }
+        ]
+      });
     });
 
 
@@ -809,11 +817,13 @@ describe('util', function() {
       ].join(' '));
 
       // then
-      expect(search).to.eql([
-        { qualifier: 'is', value: 'open.bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open.bar', negated: false, exact: true }
-      ]);
-
+      expect(search).to.eql({
+        qualifier: 'and',
+        value: [
+          { qualifier: 'is', value: 'open.bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open.bar', negated: false, exact: true }
+        ]
+      });
     });
 
 
@@ -826,11 +836,13 @@ describe('util', function() {
       ].join(' '));
 
       // then
-      expect(search).to.eql([
-        { qualifier: 'is', value: 'open_bar', negated: false, exact: false },
-        { qualifier: 'is', value: 'open_bar', negated: false, exact: true }
-      ]);
-
+      expect(search).to.eql({
+        qualifier: 'and',
+        value: [
+          { qualifier: 'is', value: 'open_bar', negated: false, exact: false },
+          { qualifier: 'is', value: 'open_bar', negated: false, exact: true }
+        ]
+      });
     });
 
 
@@ -843,10 +855,13 @@ describe('util', function() {
       ].join(' '));
 
       // then
-      expect(search).to.eql([
-        { qualifier: 'created', value: '<2020-09-14', negated: false, exact: false },
-        { qualifier: 'updated', value: '>=2020-09-14', negated: false, exact: false }
-      ]);
+      expect(search).to.eql({
+        qualifier: 'and',
+        value: [
+          { qualifier: 'created', value: '<2020-09-14', negated: false, exact: false },
+          { qualifier: 'updated', value: '>=2020-09-14', negated: false, exact: false }
+        ]
+      });
     });
 
 
@@ -858,26 +873,19 @@ describe('util', function() {
         const search = parseSearch('repo:foo/bar label:bug OR -repo:baz/qux');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'or',
-            value: [
-              {
-                qualifier: 'and',
-                value: [
-                  { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
-                  { qualifier: 'label', value: 'bug', negated: false, exact: false }
-                ]
-              },
-              {
-                qualifier: 'and',
-                value: [
-                  { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
-                ]
-              }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'or',
+          value: [
+            {
+              qualifier: 'and',
+              value: [
+                { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
+                { qualifier: 'label', value: 'bug', negated: false, exact: false }
+              ]
+            },
+            { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
+          ]
+        });
       });
 
 
@@ -887,41 +895,19 @@ describe('util', function() {
         const search = parseSearch('label:bug OR label:feature OR is:closed');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'or',
-            value: [
-              {
-                qualifier: 'and',
-                value: [
-                  { qualifier: 'label', value: 'bug', negated: false, exact: false }
-                ]
-              },
-              {
-                qualifier: 'and',
-                value: [
-                  {
-                    qualifier: 'or',
-                    value: [
-                      {
-                        qualifier: 'and',
-                        value: [
-                          { qualifier: 'label', value: 'feature', negated: false, exact: false }
-                        ]
-                      },
-                      {
-                        qualifier: 'and',
-                        value: [
-                          { qualifier: 'is', value: 'closed', negated: false, exact: false }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'or',
+          value: [
+            { qualifier: 'label', value: 'bug', negated: false, exact: false },
+            {
+              qualifier: 'or',
+              value: [
+                { qualifier: 'label', value: 'feature', negated: false, exact: false },
+                { qualifier: 'is', value: 'closed', negated: false, exact: false }
+              ]
+            }
+          ]
+        });
       });
 
 
@@ -931,10 +917,13 @@ describe('util', function() {
         const search = parseSearch('"FOO OR BAR" label:feature');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'text', value: 'FOO OR BAR', negated: false, exact: true },
-          { qualifier: 'label', value: 'feature', negated: false, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'text', value: 'FOO OR BAR', negated: false, exact: true },
+            { qualifier: 'label', value: 'feature', negated: false, exact: false }
+          ]
+        });
       });
 
 
@@ -944,11 +933,14 @@ describe('util', function() {
         const search = parseSearch('label:bug or label:feature');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'label', value: 'bug', negated: false, exact: false },
-          { qualifier: 'text', value: 'or', negated: false, exact: false },
-          { qualifier: 'label', value: 'feature', negated: false, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'label', value: 'bug', negated: false, exact: false },
+            { qualifier: 'text', value: 'or', negated: false, exact: false },
+            { qualifier: 'label', value: 'feature', negated: false, exact: false }
+          ]
+        });
       });
 
     });
@@ -962,11 +954,14 @@ describe('util', function() {
         const search = parseSearch('repo:foo/bar label:bug AND -repo:baz/qux');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
-          { qualifier: 'label', value: 'bug', negated: false, exact: false },
-          { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'repo', value: 'foo/bar', negated: false, exact: false },
+            { qualifier: 'label', value: 'bug', negated: false, exact: false },
+            { qualifier: 'repo', value: 'baz/qux', negated: true, exact: false }
+          ]
+        });
       });
 
 
@@ -976,11 +971,14 @@ describe('util', function() {
         const search = parseSearch('label:bug AND label:feature AND is:closed');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'label', value: 'bug', negated: false, exact: false },
-          { qualifier: 'label', value: 'feature', negated: false, exact: false },
-          { qualifier: 'is', value: 'closed', negated: false, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'label', value: 'bug', negated: false, exact: false },
+            { qualifier: 'label', value: 'feature', negated: false, exact: false },
+            { qualifier: 'is', value: 'closed', negated: false, exact: false }
+          ]
+        });
       });
 
 
@@ -990,10 +988,13 @@ describe('util', function() {
         const search = parseSearch('"FOO AND BAR" label:feature');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'text', value: 'FOO AND BAR', negated: false, exact: true },
-          { qualifier: 'label', value: 'feature', negated: false, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'text', value: 'FOO AND BAR', negated: false, exact: true },
+            { qualifier: 'label', value: 'feature', negated: false, exact: false }
+          ]
+        });
       });
 
 
@@ -1003,11 +1004,14 @@ describe('util', function() {
         const search = parseSearch('label:bug and label:feature');
 
         // then
-        expect(search).to.eql([
-          { qualifier: 'label', value: 'bug', negated: false, exact: false },
-          { qualifier: 'text', value: 'and', negated: false, exact: false },
-          { qualifier: 'label', value: 'feature', negated: false, exact: false }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            { qualifier: 'label', value: 'bug', negated: false, exact: false },
+            { qualifier: 'text', value: 'and', negated: false, exact: false },
+            { qualifier: 'label', value: 'feature', negated: false, exact: false }
+          ]
+        });
       });
 
     });
@@ -1020,42 +1024,25 @@ describe('util', function() {
 
       // then
       // parsed as ( label:bug OR ( (label:feature AND "bug") OR "other" ) )
-      expect(search).to.eql([
-        {
-          qualifier: 'or',
-          value: [
-            {
-              qualifier: 'and',
-              value: [
-                { qualifier: 'label', value: 'bug', negated: false, exact: false }
-              ]
-            },
-            {
-              qualifier: 'and',
-              value: [
-                {
-                  qualifier: 'or',
-                  value: [
-                    {
-                      qualifier: 'and',
-                      value: [
-                        { qualifier: 'label', value: 'feature', negated: false, exact: false },
-                        { qualifier: 'text', value: 'bug', exact: true, negated: false }
-                      ]
-                    },
-                    {
-                      qualifier: 'and',
-                      value: [
-                        { qualifier: 'text', value: 'other', exact: true, negated: false }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]);
+      expect(search).to.eql({
+        qualifier: 'or',
+        value: [
+          { qualifier: 'label', value: 'bug', negated: false, exact: false },
+          {
+            qualifier: 'or',
+            value: [
+              {
+                qualifier: 'and',
+                value: [
+                  { qualifier: 'label', value: 'feature', negated: false, exact: false },
+                  { qualifier: 'text', value: 'bug', exact: true, negated: false }
+                ]
+              },
+              { qualifier: 'text', value: 'other', exact: true, negated: false }
+            ]
+          }
+        ]
+      });
     });
 
 
@@ -1067,15 +1054,12 @@ describe('util', function() {
         const search = parseSearch('(label:feature)');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'and',
-            group: true,
-            value: [
-              { exact: false, negated: false, qualifier: 'label', value: 'feature' }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          exact: false,
+          negated: false,
+          qualifier: 'label',
+          value: 'feature'
+        });
       });
 
 
@@ -1085,16 +1069,14 @@ describe('util', function() {
         const search = parseSearch('(a b)');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'and',
-            group: true,
-            value: [
-              { exact: false, negated: false, qualifier: 'text', value: 'a' },
-              { exact: false, negated: false, qualifier: 'text', value: 'b' }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          group: true,
+          value: [
+            { exact: false, negated: false, qualifier: 'text', value: 'a' },
+            { exact: false, negated: false, qualifier: 'text', value: 'b' }
+          ]
+        });
       });
 
 
@@ -1104,31 +1086,13 @@ describe('util', function() {
         const search = parseSearch('(a OR b)');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'and',
-            group: true,
-            value: [
-              {
-                qualifier: 'or',
-                value: [
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { exact: false, negated: false, qualifier: 'text', value: 'a' }
-                    ]
-                  },
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { exact: false, negated: false, qualifier: 'text', value: 'b' }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'or',
+          value: [
+            { exact: false, negated: false, qualifier: 'text', value: 'a' },
+            { exact: false, negated: false, qualifier: 'text', value: 'b' }
+          ]
+        });
       });
 
 
@@ -1138,54 +1102,25 @@ describe('util', function() {
         const search = parseSearch('(label:bug OR label:feature) AND ("bug" OR "other")');
 
         // then
-        expect(search).to.eql([
-          {
-            qualifier: 'and',
-            group: true,
-            value: [
-              {
-                qualifier: 'or',
-                value: [
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { qualifier: 'label', value: 'bug', negated: false, exact: false }
-                    ]
-                  },
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { qualifier: 'label', value: 'feature', negated: false, exact: false }
-                    ]
-                  }
-                ]
-              }
-            ]
-          },
-          {
-            qualifier: 'and',
-            group: true,
-            value: [
-              {
-                qualifier: 'or',
-                value: [
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { qualifier: 'text', value: 'bug', exact: true, negated: false }
-                    ]
-                  },
-                  {
-                    qualifier: 'and',
-                    value: [
-                      { qualifier: 'text', value: 'other', exact: true, negated: false }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]);
+        expect(search).to.eql({
+          qualifier: 'and',
+          value: [
+            {
+              qualifier: 'or',
+              value: [
+                { qualifier: 'label', value: 'bug', negated: false, exact: false },
+                { qualifier: 'label', value: 'feature', negated: false, exact: false }
+              ]
+            },
+            {
+              qualifier: 'or',
+              value: [
+                { qualifier: 'text', value: 'bug', exact: true, negated: false },
+                { qualifier: 'text', value: 'other', exact: true, negated: false }
+              ]
+            }
+          ]
+        });
       });
 
     });

--- a/packages/app/test/util.test.js
+++ b/packages/app/test/util.test.js
@@ -688,11 +688,11 @@ describe('util', function() {
 
       // then
       expect(search).to.eql([
-        { qualifier: 'text', value: 'Copy& Paste', exact: true },
+        { qualifier: 'text', value: 'Copy& Paste', negated: false, exact: true },
         { qualifier: 'is', value: 'open', negated: false, exact: false },
-        { qualifier: 'text', value: 'asdsad', exact: false },
+        { qualifier: 'text', value: 'asdsad', negated: false, exact: false },
         { qualifier: 'milestone', value: 'FOO BAR', negated: false, exact: true },
-        { qualifier: 'text', value: 'FOO BAR', exact: true },
+        { qualifier: 'text', value: 'FOO BAR', negated: false, exact: true },
         { qualifier: 'milestone', value: '12asd', negated: false, exact: false },
         { qualifier: 'milestone', value: undefined, negated: false, exact: false },
         { qualifier: 'author', value: 'walt', negated: false, exact: false },
@@ -718,20 +718,30 @@ describe('util', function() {
     });
 
 
-    it('should parse negated (-) value', function() {
+    it('should parse negated value', function() {
 
       // when
       const search = parseSearch([
         '-is:"open:b"',
         '-is:FOO',
-        '!is:FOO'
+        '!is:FOO',
+        'NOT is:FOO',
+        '!FOO',
+        '!"FOO"',
+        'NOT NOTARIZED',
+        'NOTARIZED'
       ].join(' '));
 
       // then
       expect(search).to.eql([
         { qualifier: 'is', value: 'open:b', negated: true, exact: true },
         { qualifier: 'is', value: 'FOO', negated: true, exact: false },
-        { qualifier: 'is', value: 'FOO', negated: true, exact: false }
+        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+        { qualifier: 'is', value: 'FOO', negated: true, exact: false },
+        { qualifier: 'text', value: 'FOO', negated: true, exact: false },
+        { qualifier: 'text', value: 'FOO', negated: true, exact: true },
+        { qualifier: 'text', value: 'NOTARIZED', negated: true, exact: false },
+        { qualifier: 'text', value: 'NOTARIZED', negated: false, exact: false }
       ]);
 
     });

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -20,7 +20,7 @@
     "rollup-plugin-string": "^3.0.0",
     "rollup-plugin-svelte": "^7.2.3",
     "sass": "^1.77.4",
-    "svelte": "^5.55.4",
+    "svelte": "^5.55.5",
     "svelte-preprocess": "^6.0.3"
   },
   "engines": {

--- a/packages/board/src/BoardFilter.svelte
+++ b/packages/board/src/BoardFilter.svelte
@@ -146,7 +146,10 @@
 
     const beforeCursor = value.substring(0, searchEnd);
 
-    const searchStart = beforeCursor.lastIndexOf(' ') + 1;
+    const searchStart = Math.max(
+      beforeCursor.lastIndexOf(' '),
+      beforeCursor.lastIndexOf('(')
+    ) + 1;
 
     value = value.substring(searchStart, searchEnd).toLowerCase();
 


### PR DESCRIPTION
### Which issue does this PR address?

Allows users to filter as they'd be able to do it [on GitHub](
https://docs.github.com/en/search-github/github-code-search/understanding-github-code-search-syntax#using-boolean-operations).

Supersedes #282 
