### PR TITLE
fix: always link to specific issue or pull request URL

### DIFF
--- a/packages/board/src/Card.svelte
+++ b/packages/board/src/Card.svelte
@@ -101,7 +101,7 @@
 
   const repoUrl = $derived(`https://github.com/${ repositoryName }`);
   const milestoneUrl = $derived(milestone && (milestone.html_url || `${repoUrl}/milestone/${milestone.number}`));
-  const cardUrl = $derived(item.html_url || `${repoUrl}/issues/${number}`);
+  const cardUrl = $derived(item.html_url || `${repoUrl}/${pull_request ? 'pull' : 'issues'}/${number}`);
 
   function isClosingPull(link) {
     const {

--- a/packages/board/src/CardLink.svelte
+++ b/packages/board/src/CardLink.svelte
@@ -27,7 +27,7 @@
 
   const repositoryName = $derived(`${repository.owner.login}/${repository.name}`);
 
-  const cardUrl = $derived(`https://github.com/${ repositoryName }/issues/${ number }${ ref || '' }`);
+  const cardUrl = $derived((item.html_url || `https://github.com/${ repositoryName }/${ pull_request ? 'pull' : 'issues' }/${ number }${ ref || '' }`));
 
   const linkTitle = $derived(({
     CHILD_OF: 'Child of',


### PR DESCRIPTION
### Which issue does this PR address?

We used to link to the GitHub issue URL in some cases - knowing that GitHub is redirecting to the pull request URL. While it works, it is misleading - the URL looks like this is an issue, not a PR.