### PR TITLE
Ensure only collaborators are counted for `is:reviewed` and `is:approved` filters

### DIFF
--- a/packages/app/lib/apps/board-api-routes/board-api-filters.js
+++ b/packages/app/lib/apps/board-api-routes/board-api-filters.js
@@ -140,13 +140,15 @@ export function filterReview(review) {
   const {
     state,
     user,
-    html_url
+    html_url,
+    author_association
   } = review;
 
   return {
     state,
     html_url,
-    user: filterUser(user)
+    user: filterUser(user),
+    author_association
   };
 }
 
@@ -175,7 +177,8 @@ export function filterPull(pullRequest) {
     order,
     column,
     check_runs = [],
-    statuses = []
+    statuses = [],
+    author_association
   } = pullRequest;
 
   return {
@@ -200,7 +203,8 @@ export function filterPull(pullRequest) {
     order,
     column,
     statuses: statuses.map(filterStatus),
-    check_runs: check_runs.map(filterCheckRun)
+    check_runs: check_runs.map(filterCheckRun),
+    author_association
   };
 }
 
@@ -224,7 +228,8 @@ export function filterIssue(issue) {
     comments = [],
     links = [],
     order,
-    column
+    column,
+    author_association
   } = issue;
 
   return {
@@ -244,7 +249,8 @@ export function filterIssue(issue) {
     html_url,
     links: links.map(filterLink),
     order,
-    column
+    column,
+    author_association
   };
 
 }

--- a/packages/app/lib/apps/github-reviews/GithubReviews.js
+++ b/packages/app/lib/apps/github-reviews/GithubReviews.js
@@ -117,7 +117,8 @@ function filterReview(review) {
     submitted_at,
     state,
     user,
-    html_url
+    html_url,
+    author_association
   } = review;
 
   return {
@@ -128,6 +129,7 @@ function filterReview(review) {
     submitted_at,
     state: state.toLowerCase(),
     user: filterUser(user),
-    html_url
+    html_url,
+    author_association
   };
 }

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -71,7 +71,12 @@ export default function Search(config, logger, store) {
     return issue.pull_request;
   }
 
-  function isValidReviewer(user) {
+  function isValidReview(review) {
+
+    const {
+      user,
+      author_association
+    } = review;
 
     if (!user) {
       return false;
@@ -81,17 +86,19 @@ export default function Search(config, logger, store) {
       return treatBotsAsReviewers;
     }
 
-    return true;
+    // backwards compatibility - we did not have that
+    // data stored previously
+    return author_association ? [ 'COLLABORATOR', 'MEMBER', 'OWNER' ].includes(author_association) : true;
   }
 
   function isApproved(issue) {
     return (issue.reviews || []).some(
-      r => r.state === 'approved' && isValidReviewer(r.user)
+      r => r.state === 'approved' && isValidReview(r)
     );
   }
 
   function isReviewed(issue) {
-    return (issue.reviews || []).some(r => isValidReviewer(r.user));
+    return (issue.reviews || []).some(isValidReview);
   }
 
   const filters = {

--- a/packages/app/lib/filters.js
+++ b/packages/app/lib/filters.js
@@ -149,7 +149,8 @@ export function filterPull(githubPull, githubRepository) {
     additions,
     deletions,
     changed_files,
-    html_url
+    html_url,
+    author_association
   } = githubPull;
 
   // stable ID that is independent from GitHubs internal issue/pr distinction
@@ -189,7 +190,8 @@ export function filterPull(githubPull, githubRepository) {
     changed_files,
     pull_request: true,
     repository: filterRepository(githubRepository),
-    html_url
+    html_url,
+    author_association
   };
 }
 
@@ -211,7 +213,8 @@ export function filterIssue(githubIssue, githubRepository) {
     labels,
     milestone,
     pull_request,
-    html_url
+    html_url,
+    author_association
   } = githubIssue;
 
   // stable ID that is independent from GitHubs internal issue/pr distinction
@@ -241,7 +244,8 @@ export function filterIssue(githubIssue, githubRepository) {
     milestone: milestone ? filterMilestone(milestone) : null,
     repository: filterRepository(githubRepository),
     pull_request: !!pull_request,
-    html_url
+    html_url,
+    author_association
   };
 
 }

--- a/packages/app/test/apps/board-api-routes/issues.filtered.json
+++ b/packages/app/test/apps/board-api-routes/issues.filtered.json
@@ -31,7 +31,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       },
       {
         "state": "approved",
@@ -41,7 +42,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       },
       {
         "state": "changes_requested",
@@ -51,7 +53,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       },
       {
         "state": "approved",
@@ -61,7 +64,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       },
       {
         "state": "changes_requested",
@@ -71,7 +75,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       },
       {
         "state": "approved",
@@ -81,7 +86,8 @@
           "avatar_url": "https://avatars.githubusercontent.com/u/43684505?u=7d484e008242e75626e637ee648e2179ebe9368b&v=4",
           "html_url": "https://github.com/waltaaa",
           "type": "User"
-        }
+        },
+        "author_association": "COLLABORATOR"
       }
     ],
     "draft": false,
@@ -186,7 +192,8 @@
           "html_url": "https://github.com/nikku/testtest-checks/issues/6",
           "links": [],
           "order": 709876.54321,
-          "column": "Needs Review"
+          "column": "Needs Review",
+          "author_association": "OWNER"
         },
         "ref": "#ref"
       }
@@ -207,7 +214,8 @@
         "name": "Travis CI - Branch",
         "html_url": "https://github.com/nikku/testtest-checks/runs/741283950"
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-91",
@@ -292,12 +300,14 @@
           "html_url": "https://github.com/nikku/wuffle/issues/90",
           "links": [],
           "order": -3768494.9777300013,
-          "column": "Done"
+          "column": "Done",
+          "author_association": "OWNER"
         }
       }
     ],
     "order": -2511408.235010001,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-16",
@@ -336,7 +346,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/16",
     "links": [],
     "order": -2432840.313590001,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-15",
@@ -379,7 +390,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/15",
     "links": [],
     "order": -2354272.392170001,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-95",
@@ -459,12 +471,14 @@
           "html_url": "https://github.com/nikku/wuffle/issues/94",
           "links": [],
           "order": -3454223.292050001,
-          "column": "Done"
+          "column": "Done",
+          "author_association": "OWNER"
         }
       }
     ],
     "order": -2275704.470750001,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-124",
@@ -557,7 +571,8 @@
           "html_url": "https://github.com/nikku/wuffle/issues/116",
           "links": [],
           "order": -2040000.7064900007,
-          "column": "Backlog"
+          "column": "Backlog",
+          "author_association": "OWNER"
         }
       }
     ],
@@ -595,7 +610,8 @@
         "name": "Build",
         "html_url": "https://github.com/nikku/wuffle/runs/4198847426?check_suite_focus=true"
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-116",
@@ -721,12 +737,14 @@
               "name": "Build",
               "html_url": "https://github.com/nikku/wuffle/runs/4198847426?check_suite_focus=true"
             }
-          ]
+          ],
+          "author_association": "OWNER"
         }
       }
     ],
     "order": -2040000.7064900007,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-74",
@@ -774,7 +792,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/74",
     "links": [],
     "order": -1961432.7850700007,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "159565926-3",
@@ -829,7 +848,8 @@
     "order": -1175753.5708700004,
     "column": "Backlog",
     "statuses": [],
-    "check_runs": []
+    "check_runs": [],
+    "author_association": "OWNER"
   },
   {
     "id": "159565926-4",
@@ -873,7 +893,8 @@
     "order": -1097185.6494500004,
     "column": "Backlog",
     "statuses": [],
-    "check_runs": []
+    "check_runs": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-83",
@@ -967,7 +988,8 @@
           "html_url": "https://github.com/nikku/testtest/issues/76",
           "links": [],
           "order": 2765.250429999898,
-          "column": "Backlog"
+          "column": "Backlog",
+          "author_association": "OWNER"
         }
       },
       {
@@ -1014,14 +1036,16 @@
           "order": -782913.9637700003,
           "column": "Needs Review",
           "statuses": [],
-          "check_runs": []
+          "check_runs": [],
+          "author_association": "OWNER"
         }
       }
     ],
     "order": -625778.1209300002,
     "column": "Backlog",
     "statuses": [],
-    "check_runs": []
+    "check_runs": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-110",
@@ -1065,7 +1089,8 @@
     "order": -547210.1995100002,
     "column": "Backlog",
     "statuses": [],
-    "check_runs": []
+    "check_runs": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-95",
@@ -1145,12 +1170,14 @@
           "html_url": "https://github.com/nikku/testtest/issues/94",
           "links": [],
           "order": 474172.77894999995,
-          "column": "Inbox"
+          "column": "Inbox",
+          "author_association": "OWNER"
         }
       }
     ],
     "order": -75802.6709900001,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-76",
@@ -1262,7 +1289,8 @@
           "html_url": "https://github.com/nikku/testtest/issues/81",
           "links": [],
           "order": 709876.54321,
-          "column": "Needs Review"
+          "column": "Needs Review",
+          "author_association": "OWNER"
         }
       },
       {
@@ -1311,7 +1339,8 @@
           "html_url": "https://github.com/nikku/testtest/issues/74",
           "links": [],
           "order": 631308.62179,
-          "column": "Needs Review"
+          "column": "Needs Review",
+          "author_association": "OWNER"
         }
       },
       {
@@ -1372,12 +1401,14 @@
           "order": -625778.1209300002,
           "column": "Backlog",
           "statuses": [],
-          "check_runs": []
+          "check_runs": [],
+          "author_association": "OWNER"
         }
       }
     ],
     "order": 2765.250429999898,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-102",
@@ -1416,7 +1447,8 @@
     "html_url": "https://github.com/nikku/testtest/issues/102",
     "links": [],
     "order": 81333.1718499999,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-77",
@@ -1496,7 +1528,8 @@
           "html_url": "https://github.com/nikku/testtest/issues/80",
           "links": [],
           "order": 238469.0146899999,
-          "column": "Inbox"
+          "column": "Inbox",
+          "author_association": "OWNER"
         }
       },
       {
@@ -1545,7 +1578,8 @@
           "html_url": "https://github.com/nikku/testtest/issues/74",
           "links": [],
           "order": 631308.62179,
-          "column": "Needs Review"
+          "column": "Needs Review",
+          "author_association": "OWNER"
         }
       },
       {
@@ -1622,11 +1656,13 @@
           "html_url": "https://github.com/nikku/testtest/issues/81",
           "links": [],
           "order": 709876.54321,
-          "column": "Needs Review"
+          "column": "Needs Review",
+          "author_association": "OWNER"
         }
       }
     ],
     "order": 317036.9361099999,
-    "column": "Backlog"
+    "column": "Backlog",
+    "author_association": "OWNER"
   }
 ]

--- a/packages/app/test/apps/board-api-routes/issues.json
+++ b/packages/app/test/apps/board-api-routes/issues.json
@@ -151,7 +151,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425035349"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425035349",
+        "author_association": "COLLABORATOR"
       },
       {
         "id": 425035431,
@@ -168,7 +169,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425035431"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425035431",
+        "author_association": "COLLABORATOR"
       },
       {
         "id": 425039137,
@@ -185,7 +187,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425039137"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425039137",
+        "author_association": "COLLABORATOR"
       },
       {
         "id": 425039219,
@@ -202,7 +205,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425039219"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425039219",
+        "author_association": "COLLABORATOR"
       },
       {
         "id": 425040270,
@@ -219,7 +223,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425040270"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425040270",
+        "author_association": "COLLABORATOR"
       },
       {
         "id": 425040354,
@@ -236,7 +241,8 @@
           "html_url": "https://github.com/waltaaa",
           "type": "User"
         },
-        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425040354"
+        "html_url": "https://github.com/nikku/testtest-checks/pull/7#pullrequestreview-425040354",
+        "author_association": "COLLABORATOR"
       }
     ],
     "statuses": [],
@@ -365,10 +371,12 @@
                 "type": "User"
               }
             }
-          ]
+          ],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-91",
@@ -487,10 +495,12 @@
                 "type": "User"
               }
             }
-          ]
+          ],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-16",
@@ -545,7 +555,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/16",
     "column": "Backlog",
     "order": -2432840.313590001,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-15",
@@ -606,7 +617,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/15",
     "column": "Backlog",
     "order": -2354272.392170001,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-95",
@@ -720,10 +732,12 @@
           "html_url": "https://github.com/nikku/wuffle/issues/94",
           "column": "Done",
           "order": -3454223.292050001,
-          "comments": []
+          "comments": [],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-124",
@@ -956,10 +970,12 @@
           "html_url": "https://github.com/nikku/wuffle/issues/116",
           "column": "Backlog",
           "order": -2040000.7064900007,
-          "comments": []
+          "comments": [],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-116",
@@ -1191,10 +1207,12 @@
             }
           ],
           "reviews": [],
-          "statuses": []
+          "statuses": [],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "176821946-74",
@@ -1262,7 +1280,8 @@
     "html_url": "https://github.com/nikku/wuffle/issues/74",
     "column": "Backlog",
     "order": -1961432.7850700007,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "159565926-3",
@@ -1391,7 +1410,8 @@
     "html_url": "https://github.com/nikku/testtest-checks/pull/3",
     "column": "Backlog",
     "order": -1175753.5708700004,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "159565926-4",
@@ -1505,7 +1525,8 @@
     "html_url": "https://github.com/nikku/testtest-checks/pull/4",
     "column": "Backlog",
     "order": -1097185.6494500004,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-83",
@@ -1692,7 +1713,8 @@
           "pull_request": false,
           "html_url": "https://github.com/nikku/testtest/issues/76",
           "column": "Backlog",
-          "order": 2765.250429999898
+          "order": 2765.250429999898,
+          "author_association": "OWNER"
         }
       },
       {
@@ -1808,10 +1830,12 @@
           },
           "html_url": "https://github.com/nikku/testtest/pull/92",
           "column": "Needs Review",
-          "order": -782913.9637700003
+          "order": -782913.9637700003,
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-110",
@@ -1925,7 +1949,8 @@
     "html_url": "https://github.com/nikku/testtest/pull/110",
     "column": "Backlog",
     "order": -547210.1995100002,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-95",
@@ -2038,10 +2063,12 @@
           "pull_request": false,
           "html_url": "https://github.com/nikku/testtest/issues/94",
           "column": "Inbox",
-          "order": 474172.77894999995
+          "order": 474172.77894999995,
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-76",
@@ -2201,7 +2228,8 @@
                 "type": "User"
               }
             }
-          ]
+          ],
+          "author_association": "OWNER"
         }
       },
       {
@@ -2267,7 +2295,8 @@
           "pull_request": false,
           "html_url": "https://github.com/nikku/testtest/issues/74",
           "column": "Needs Review",
-          "order": 631308.62179
+          "order": 631308.62179,
+          "author_association": "OWNER"
         }
       },
       {
@@ -2401,10 +2430,12 @@
           },
           "html_url": "https://github.com/nikku/testtest/pull/83",
           "column": "Backlog",
-          "order": -625778.1209300002
+          "order": -625778.1209300002,
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-102",
@@ -2459,7 +2490,8 @@
     "html_url": "https://github.com/nikku/testtest/issues/102",
     "column": "Backlog",
     "order": 81333.1718499999,
-    "links": []
+    "links": [],
+    "author_association": "OWNER"
   },
   {
     "id": "150751504-77",
@@ -2571,7 +2603,8 @@
           "pull_request": false,
           "html_url": "https://github.com/nikku/testtest/issues/80",
           "column": "Inbox",
-          "order": 238469.0146899999
+          "order": 238469.0146899999,
+          "author_association": "OWNER"
         }
       },
       {
@@ -2637,7 +2670,8 @@
           "pull_request": false,
           "html_url": "https://github.com/nikku/testtest/issues/74",
           "column": "Needs Review",
-          "order": 631308.62179
+          "order": 631308.62179,
+          "author_association": "OWNER"
         }
       },
       {
@@ -2744,9 +2778,11 @@
                 "type": "User"
               }
             }
-          ]
+          ],
+          "author_association": "OWNER"
         }
       }
-    ]
+    ],
+    "author_association": "OWNER"
   }
 ]

--- a/packages/app/test/apps/search/Search.test.js
+++ b/packages/app/test/apps/search/Search.test.js
@@ -196,8 +196,9 @@ describe('search - Search', function() {
 
   describe('is:approved', function() {
 
-    const botReview = { user: { login: 'copilot[bot]', type: 'Bot' }, state: 'approved' };
-    const humanReview = { user: { login: 'nikku', type: 'User' }, state: 'approved' };
+    const botReview = { user: { login: 'copilot[bot]', type: 'Bot' }, author_association: 'COLLABORATOR', state: 'approved' };
+    const collaboratorReview = { user: { login: 'nikku', type: 'User' }, author_association: 'COLLABORATOR', state: 'approved' };
+    const nonCollaboratorReview = { user: { login: 'outsider', type: 'User' }, author_association: 'NONE', state: 'approved' };
 
 
     it('should NOT count bot approvals', function() {
@@ -213,13 +214,26 @@ describe('search - Search', function() {
     });
 
 
-    it('should count human approved', function() {
+    it('should NOT count non-collaborator approvals', function() {
 
       // given
-      const search = createSearch({ treatBotsAsReviewers: false });
+      const search = createSearch();
       const filter = search.getSearchFilter('is:approved');
 
-      const pr = createIssue({ pull_request: true, reviews: [ botReview, humanReview ] });
+      const pr = createIssue({ pull_request: true, reviews: [ nonCollaboratorReview ] });
+
+      // when + then
+      expect(filter(pr)).to.be.false;
+    });
+
+
+    it('should count collaborator approvals', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('is:approved');
+
+      const pr = createIssue({ pull_request: true, reviews: [ collaboratorReview ] });
 
       // when + then
       expect(filter(pr)).to.be.true;
@@ -228,7 +242,7 @@ describe('search - Search', function() {
 
     describe('with treatBotsAsReviewers=true', function() {
 
-      it('should count bot approved', function() {
+      it('should count bot approvals', function() {
 
         // given
         const search = createSearch({ treatBotsAsReviewers: true });
@@ -247,8 +261,9 @@ describe('search - Search', function() {
 
   describe('is:reviewed', function() {
 
-    const botReview = { user: { login: 'copilot[bot]', type: 'Bot' }, state: 'approved' };
-    const humanReview = { user: { login: 'nikku', type: 'User' }, state: 'approved' };
+    const botReview = { user: { login: 'copilot[bot]', type: 'Bot' }, author_association: 'COLLABORATOR', state: 'changes_requested' };
+    const collaboratorReview = { user: { login: 'nikku', type: 'User' }, author_association: 'COLLABORATOR', state: 'changes_requested' };
+    const nonCollaboratorReview = { user: { login: 'outsider', type: 'User' }, author_association: 'NONE', state: 'changes_requested' };
 
 
     it('should NOT count bot reviews', function() {
@@ -264,13 +279,26 @@ describe('search - Search', function() {
     });
 
 
-    it('should count human reviews', function() {
+    it('should NOT count non-collaborator reviews', function() {
 
       // given
-      const search = createSearch({ treatBotsAsReviewers: false });
+      const search = createSearch();
       const filter = search.getSearchFilter('is:reviewed');
 
-      const pr = createIssue({ pull_request: true, reviews: [ botReview, humanReview ] });
+      const pr = createIssue({ pull_request: true, reviews: [ nonCollaboratorReview ] });
+
+      // when + then
+      expect(filter(pr)).to.be.false;
+    });
+
+
+    it('should count collaborator reviews', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('is:reviewed');
+
+      const pr = createIssue({ pull_request: true, reviews: [ collaboratorReview ] });
 
       // when + then
       expect(filter(pr)).to.be.true;

--- a/packages/app/test/fixtures/filters/filtered/issue-with-milestone.json
+++ b/packages/app/test/fixtures/filters/filtered/issue-with-milestone.json
@@ -52,5 +52,6 @@
     "html_url": "https://github.com/nikku/testtest"
   },
   "pull_request": true,
-  "html_url": "https://github.com/nikku/testtest/pull/75"
+  "html_url": "https://github.com/nikku/testtest/pull/75",
+  "author_association": "OWNER"
 }

--- a/packages/app/test/fixtures/filters/filtered/pull_request.background-synched.json
+++ b/packages/app/test/fixtures/filters/filtered/pull_request.background-synched.json
@@ -119,5 +119,6 @@
     },
     "html_url": "https://github.com/nikku/testtest"
   },
-  "html_url": "https://github.com/nikku/testtest/pull/75"
+  "html_url": "https://github.com/nikku/testtest/pull/75",
+  "author_association": "OWNER"
 }

--- a/packages/app/test/fixtures/filters/filtered/pull_request.json
+++ b/packages/app/test/fixtures/filters/filtered/pull_request.json
@@ -119,5 +119,6 @@
     },
     "html_url": "https://github.com/nikku/testtest"
   },
-  "html_url": "https://github.com/nikku/testtest/pull/75"
+  "html_url": "https://github.com/nikku/testtest/pull/75",
+  "author_association": "OWNER"
 }


### PR DESCRIPTION
### Which issue does this PR address?

Related to https://github.com/nikku/wuffle/pull/290, ensures that only contributor reviews are "counted" as valid reviews as per `is:reviewed` and `is:approved` filters.
