### PR TITLE
Compute `is:approved` from effective reviews

### DIFF
--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -91,14 +91,26 @@ export default function Search(config, logger, store) {
     return author_association ? [ 'COLLABORATOR', 'MEMBER', 'OWNER' ].includes(author_association) : true;
   }
 
+  function getEffectiveReviews(reviews) {
+    const byReviewer = new Map();
+
+    for (const review of reviews) {
+      if (review.state === 'commented' || !isValidReview(review)) continue;
+
+      byReviewer.set(review.user?.login, review);
+    }
+
+    return [ ...byReviewer.values() ];
+  }
+
   function isApproved(issue) {
-    return (issue.reviews || []).some(
-      r => r.state === 'approved' && isValidReview(r)
+    return getEffectiveReviews(issue.reviews || []).some(
+      r => r.state === 'approved'
     );
   }
 
   function isReviewed(issue) {
-    return (issue.reviews || []).some(isValidReview);
+    return getEffectiveReviews(issue.reviews || []).length > 0;
   }
 
   const filters = {

--- a/packages/app/test/apps/search/Search.test.js
+++ b/packages/app/test/apps/search/Search.test.js
@@ -238,6 +238,44 @@ describe('apps/search - Search', function() {
     });
 
 
+    it('should NOT count approval superseded by changes_requested', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('is:approved');
+
+      const pr = createIssue({
+        pull_request: true,
+        reviews: [
+          { ...collaboratorReview, state: 'approved' },
+          { ...collaboratorReview, state: 'changes_requested' }
+        ]
+      });
+
+      // when + then
+      expect(filter(pr)).to.be.false;
+    });
+
+
+    it('should count approval after changes_requested', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('is:approved');
+
+      const pr = createIssue({
+        pull_request: true,
+        reviews: [
+          { ...collaboratorReview, state: 'changes_requested' },
+          { ...collaboratorReview, state: 'approved' }
+        ]
+      });
+
+      // when + then
+      expect(filter(pr)).to.be.true;
+    });
+
+
     describe('with treatBotsAsReviewers=true', function() {
 
       it('should count bot approvals', function() {
@@ -300,6 +338,38 @@ describe('apps/search - Search', function() {
 
       // when + then
       expect(filter(pr)).to.be.true;
+    });
+
+
+    it('should NOT count comment-only review', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('is:reviewed');
+
+      const pr = createIssue({
+        pull_request: true,
+        reviews: [ { ...collaboratorReview, state: 'commented' } ]
+      });
+
+      // when + then
+      expect(filter(pr)).to.be.false;
+    });
+
+
+    it('should count approval', function() {
+
+      // given
+      const search = createSearch();
+      const reviewedFilter = search.getSearchFilter('is:reviewed');
+
+      const pr = createIssue({
+        pull_request: true,
+        reviews: [ { ...collaboratorReview, state: 'approved' } ]
+      });
+
+      // when + then
+      expect(reviewedFilter(pr)).to.be.true;
     });
 
 

--- a/packages/app/test/apps/search/Search.test.js
+++ b/packages/app/test/apps/search/Search.test.js
@@ -292,6 +292,90 @@ describe('apps/search - Search', function() {
 
     });
 
+
+    describe('via CLOSED_BY link', function() {
+
+      it('should match issue if closing PR is approved', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:approved');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [ collaboratorReview ] })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.true;
+      });
+
+
+      it('should NOT match issue if closing PR is not approved', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:approved');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [] })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.false;
+      });
+
+
+      it('should match issue if ONE closing PR is approved', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:approved');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({
+                pull_request: true,
+                reviews: [ collaboratorReview ]
+              })
+            },
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [] })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.true;
+      });
+
+
+      it('should NOT match issue with no CLOSED_BY links', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:approved');
+
+        const issue = createIssue({ links: [] });
+
+        // when + then
+        expect(filter(issue)).to.be.false;
+      });
+
+    });
+
   });
 
 
@@ -385,6 +469,91 @@ describe('apps/search - Search', function() {
 
         // when + then
         expect(filter(pr)).to.be.true;
+      });
+
+    });
+
+
+    describe('via CLOSED_BY link', function() {
+
+      it('should match issue if closing PR is reviewed', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:reviewed');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({
+                pull_request: true,
+                reviews: [ collaboratorReview ]
+              })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.true;
+      });
+
+
+      it('should NOT match issue if closing PR is not reviewed', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:reviewed');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [] })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.false;
+      });
+
+
+
+      it('should match issue if ONE some closing PR is reviewed', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:reviewed');
+
+        const issue = createIssue({
+          links: [
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [ collaboratorReview ] })
+            },
+            {
+              type: LinkTypes.CLOSED_BY,
+              target: createIssue({ pull_request: true, reviews: [] })
+            }
+          ]
+        });
+
+        // when + then
+        expect(filter(issue)).to.be.true;
+      });
+
+
+      it('should NOT match issue with no CLOSED_BY links', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:reviewed');
+
+        const issue = createIssue({ links: [] });
+
+        // when + then
+        expect(filter(issue)).to.be.false;
       });
 
     });


### PR DESCRIPTION
### Which issue does this PR address?

While on the board we already computed the effective review state and indicated on a card, we did not do the same thing for `is:reviewed` and `is:approved` filters: An issue that was `approved` earlier, and then `changes_requested` by the same user would still hold the "approved" stamp.

This PR fixes the behavior - mirroring GitHub giving precedence to the latest review - only if
the last review per valid reviewer is approved, then the pull request is approved.
