### PR TITLE
Add ability to ignore (not store) certain issues 

### DIFF
--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -477,4 +477,6 @@ export default function Search(config, logger, store) {
   // api ///////////////////////
 
   this.getSearchFilter = getSearchFilter;
+
+  this.buildFilterFn = buildFilterFn;
 }

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -446,9 +446,11 @@ export default function Search(config, logger, store) {
    */
   function getSearchFilter(search, user) {
 
-    const filterFn = buildFilterFn(search, user);
+    if (!search) {
+      search = config.defaultFilter;
+    }
 
-    const ignoreFilterFn = buildFilterFn(config.defaultFilter, user);
+    const filterFn = buildFilterFn(search, user);
 
     return function(issue) {
       try {
@@ -456,12 +458,7 @@ export default function Search(config, logger, store) {
           return filterFn(issue);
         }
 
-        if (ignoreFilterFn) {
-          return ignoreFilterFn(issue);
-        }
-
-        // no user search, no ignore filter,
-        // show all issues
+        // no search, show all issues
         return true;
       } catch (err) {
         log.warn({ issue: issueIdent(issue), err }, 'filter failed');

--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -8,7 +8,11 @@ const CHILD_LINK_TYPES = {
 };
 
 /**
- * @typedef { { defaultFilter?: string, treatBotsAsReviewers?: boolean } } SearchConfig
+ * @typedef { {
+ *   defaultFilter?: string,
+ *   treatBotsAsReviewers?: boolean
+ * } } SearchConfig
+ *
  * @typedef { import('../../util/search.js').SearchTerm } SearchTerm
  *
  * @typedef { import('../../types.js').GitHubUser } GitHubUser
@@ -32,7 +36,8 @@ export default function Search(config, logger, store) {
   });
 
   const {
-    treatBotsAsReviewers = false
+    treatBotsAsReviewers = false,
+    defaultFilter
   } = config;
 
   function filterNoop(issue) {
@@ -447,7 +452,7 @@ export default function Search(config, logger, store) {
   function getSearchFilter(search, user) {
 
     if (!search) {
-      search = config.defaultFilter;
+      search = defaultFilter;
     }
 
     const filterFn = buildFilterFn(search, user);

--- a/packages/app/lib/apps/store-filter.js
+++ b/packages/app/lib/apps/store-filter.js
@@ -1,0 +1,22 @@
+/**
+ * @typedef { { ignoreFilter?: string } } StoreFilterConfig
+ */
+
+/**
+ * An component that configures the store to filter certain elements,
+ * effectively making them invisible to the board and its users.
+ *
+ * @param { StoreFilterConfig } config
+ *
+ * @param { import('../store.js').default } store
+ * @param { import('./search/Search.js').default } search
+ */
+export default function StoreFilter(config, store, search) {
+
+  if ('ignoreFilter' in config) {
+    const ignoreFilterFn = search.buildFilterFn(config.ignoreFilter);
+
+    store.setIgnoreFilter(ignoreFilterFn);
+  }
+
+}

--- a/packages/app/lib/index.js
+++ b/packages/app/lib/index.js
@@ -27,7 +27,8 @@ const appModules = [
   import('./apps/auth-routes/index.js'),
   import('./apps/board-api-routes/index.js'),
   import('./apps/board-routes.js'),
-  import('./apps/reindex-store.js')
+  import('./apps/reindex-store.js'),
+  import('./apps/store-filter.js')
 ];
 
 import loadConfig from './load-config.js';

--- a/packages/app/lib/store.js
+++ b/packages/app/lib/store.js
@@ -4,6 +4,9 @@ import { issueIdent } from './util/index.js';
 import { findLinks } from './util/links.js';
 import { Links } from './links.js';
 
+/**
+ * @typedef { import('./apps/search/Search.js').FilterFn } FilterFn
+ */
 
 /**
  * The store that holds all board data
@@ -39,6 +42,10 @@ export default class Store {
     this.updateContext = null;
     this.queuedUpdates = [];
 
+    /**
+     * @type { FilterFn }
+     */
+    this.ignoreFilter = (issue) => false;
 
     this.on('updateIssue', async event => {
 
@@ -303,7 +310,9 @@ export default class Store {
   /**
    * Update issue, tagging it as updated.
    *
-   * @return {Promise<Object>} promise to updated issue
+   * If issue matches the ignore filter it will be removed as part of the update.
+   *
+   * @return {Promise<Object|undefined>} a promise to the updated issue or undefined in case the update triggered issue deletion
    */
   updateIssue(update) {
 
@@ -373,6 +382,14 @@ export default class Store {
     }
 
     const ident = issueIdent(updatedIssue);
+
+    if (this.ignoreFilter(updatedIssue)) {
+      this.log.debug({ issue: ident }, 'issue matching ignore filter');
+
+      await this.removeIssueById(id);
+
+      return null;
+    }
 
     this.log.debug({
       issue: ident
@@ -859,6 +876,13 @@ export default class Store {
       issues: issues.length,
       lastSync
     }, 'load JSON complete');
+  }
+
+  /**
+   * @param { FilterFn } ignoreFilter
+   */
+  setIgnoreFilter(ignoreFilter) {
+    this.ignoreFilter = ignoreFilter;
   }
 
 }

--- a/packages/app/test/apps/search/Search.test.js
+++ b/packages/app/test/apps/search/Search.test.js
@@ -599,4 +599,69 @@ describe('apps/search - Search', function() {
 
   });
 
+
+  describe('user and default filter', function() {
+
+    const openIssue = createIssue({ state: 'open' });
+    const closedIssue = createIssue({ state: 'closed' });
+
+
+    describe('no default filter', function() {
+
+      it('should handle no user search', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('');
+
+        // when + then
+        expect(filter(openIssue)).to.be.true;
+        expect(filter(closedIssue)).to.be.true;
+      });
+
+
+      it('should apply user search', function() {
+
+        // given
+        const search = createSearch();
+        const filter = search.getSearchFilter('is:closed');
+
+        // when + then
+        expect(filter(openIssue)).to.be.false;
+        expect(filter(closedIssue)).to.be.true;
+      });
+
+    });
+
+
+    describe('with default filter', function() {
+
+      it('should apply default filter if no user search', function() {
+
+        // given
+        const search = createSearch({ defaultFilter: 'is:open' });
+        const filter = search.getSearchFilter('');
+
+        // when + then
+        expect(filter(openIssue)).to.be.true;
+        expect(filter(closedIssue)).to.be.false;
+      });
+
+
+      it('should apply user search over default filter', function() {
+
+        // given
+        const search = createSearch({ defaultFilter: 'is:open' });
+        const filter = search.getSearchFilter('is:closed');
+
+        // when + then
+        // user filter wins over default filter
+        expect(filter(openIssue)).to.be.false;
+        expect(filter(closedIssue)).to.be.true;
+      });
+
+    });
+
+  });
+
 });

--- a/packages/app/test/store.test.js
+++ b/packages/app/test/store.test.js
@@ -330,6 +330,120 @@ describe('store', function() {
   });
 
 
+  describe('ignore filter', function() {
+
+    it('should not add issue if ignored on create', async function() {
+
+      // given
+      const store = createStore();
+
+      store.setIgnoreFilter(issue => issue.state === 'closed');
+
+      // when
+      const update = await store.updateIssue(createIssue({ state: 'closed' }));
+
+      // then
+      expect(store.getIssues()).to.be.empty;
+
+      expect(update).to.be.undefined;
+    });
+
+
+    it('should remove existing issue if ignored on update', async function() {
+
+      // given
+      const store = createStore();
+
+      const { id } = await store.updateIssue(createIssue({ state: 'open' }));
+
+      store.setIgnoreFilter(issue => issue.state === 'closed');
+
+      // when
+      const update = await store.updateIssue({ id, state: 'closed' });
+
+      // then
+      expect(store.getIssues()).to.be.empty;
+
+      expect(update).to.be.undefined;
+    });
+
+
+    it('should keep issue if not ignored', async function() {
+
+      // given
+      const store = createStore();
+
+      store.setIgnoreFilter(issue => issue.state === 'closed');
+
+      // when
+      const issue = await store.updateIssue(createIssue({ state: 'open' }));
+
+      // then
+      expect(store.getIssues()).to.eql([ issue ]);
+    });
+
+
+    describe('updates', function() {
+
+      it('should not include ignored issue during creation', async function() {
+
+        // given
+        const store = createStore();
+
+        store.setIgnoreFilter(issue => issue.state === 'closed');
+
+        // when
+        await store.updateIssue(createIssue({ state: 'closed' }));
+
+        // then
+        expect(store.updates.getSince()).to.have.length(0);
+      });
+
+
+      it('should include ignored issue during removal', async function() {
+
+        // given
+        const store = createStore();
+
+        store.setIgnoreFilter(issue => issue.state === 'closed');
+
+        const [
+          issue1,
+          issue2,
+          issue3
+        ] = await Promise.all([
+          store.updateIssue(createIssue({ state: 'open' })),
+          store.updateIssue(createIssue({ state: 'open' })),
+          store.updateIssue(createIssue({ state: 'open' }))
+        ]);
+
+        // when
+        await Promise.all([
+          store.updateIssue({ id: issue1.id, state: 'closed' }),
+          store.updateIssue({ id: issue2.id }),
+          store.updateIssue({ id: issue3.id, state: 'closed' })
+        ]);
+
+        const updates = store.updates.getSince();
+
+        // then
+        const results = updates.map(update => ({
+          issueId: update.issue.id,
+          type: update.type
+        }));
+
+        expect(results).to.eql([
+          { issueId: issue1.id, type: 'remove' },
+          { issueId: issue3.id, type: 'remove' },
+          { issueId: issue2.id, type: 'update' }
+        ]);
+      });
+
+    });
+
+  });
+
+
   describe('updates', function() {
 
     it('should always return cursor', function() {

--- a/packages/app/wuffle.config.example.js
+++ b/packages/app/wuffle.config.example.js
@@ -34,6 +34,11 @@
  * You may define a default filter to apply to the board if
  * there is no user-defined search query.
  *
+ * You may choose to ignore certain issues from connected repositories
+ * through an ignore filter. Matching issues will not be added (saved) to
+ * the board. If they matched previously (before an update) they will be
+ * removed as part of an update.
+ *
  * You may also configure whether bots are counted as
  * legitimate reviewers (for both review and approval).
  */
@@ -52,6 +57,8 @@ export default {
   ],
 
   defaultFilter: '!repo:"some/ignored-repository"',
+
+  ignoreFilter: 'label:"invalid"',
 
   treatBotsAsReviewers: false
 };


### PR DESCRIPTION
### Which issue does this PR address?

Via https://github.com/nikku/wuffle/commit/91bd419787d7865bf3fc1a2a2730b0a5827d910f we add an `ignoreFilter` option to the board - matching issues will be removed from / not added to the board.

Closes https://github.com/nikku/wuffle/issues/287
