### PR TITLE
fix: use user context for filtering

### DIFF
--- a/packages/app/lib/apps/search/Search.js
+++ b/packages/app/lib/apps/search/Search.js
@@ -438,7 +438,7 @@ export default function Search(config, logger, store) {
       return null;
     }
 
-    return buildTermFn(term);
+    return buildTermFn(term, user);
   }
 
   /**

--- a/packages/app/test/apps/search/Search.test.js
+++ b/packages/app/test/apps/search/Search.test.js
@@ -560,6 +560,58 @@ describe('apps/search - Search', function() {
   });
 
 
+  describe('assignee', function() {
+
+    const user = { login: 'nikku', last_checked: 0, access_token: 'token', avatar_url: 'url' };
+    const anotherUser = { login: 'outsider', last_checked: 0, access_token: 'token', avatar_url: 'url' };
+
+
+    it('should support assignee filter', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('assignee:nikku');
+
+      const issue = createIssue({ assignees: [ user ] });
+      const anotherAssigneeIssue = createIssue({ assignees: [ anotherUser ] });
+
+      // when + then
+      expect(filter(issue)).to.be.true;
+      expect(filter(anotherAssigneeIssue)).to.be.false;
+    });
+
+
+    it('should support assignee:@me filter', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('assignee:@me', user);
+
+      const issue = createIssue({ assignees: [ user ] });
+      const anotherAssigneeIssue = createIssue({ assignees: [ anotherUser ] });
+
+      // when + then
+      expect(filter(issue)).to.be.true;
+      expect(filter(anotherAssigneeIssue)).to.be.false;
+    });
+
+
+    it('should filter out if no user is provided for assignee:@me filter', function() {
+
+      // given
+      const search = createSearch();
+      const filter = search.getSearchFilter('assignee:@me');
+
+      const issue = createIssue({ assignees: [ user ] });
+      const anotherAssigneeIssue = createIssue({ assignees: [ anotherUser ] });
+
+      // when + then
+      expect(filter(issue)).to.be.false;
+      expect(filter(anotherAssigneeIssue)).to.be.false;
+    });
+  });
+
+
   describe('OR', function() {
 
     const collaboratorReview = { user: { login: 'nikku', type: 'User' }, author_association: 'COLLABORATOR', state: 'changes_requested' };


### PR DESCRIPTION
With the recent changes, the `@me` utility broke. This PR fixes the problem which was about missing parameter passed to a function.

### Which issue does this PR address?

No issue created as it was a quick fix.

Cf. https://camunda.slack.com/archives/GP70M0J6M/p1777892149302319