### PR TITLE
Ensure that details are only synchronized for stored issues

### DIFF
--- a/packages/app/CHANGELOG.md
+++ b/packages/app/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [wuffle](https://github.com/nikku/wuffle) are documented 
 
 _**Note:** Yet to be released changes appear here._
 
+## 0.73.3
+
+* `FEAT`: only background sync details for updated issues ([#299](https://github.com/nikku/wuffle/pull/299))
+* `FIX`: ensure details sync adheres to `ignoreFilter` ([#299](https://github.com/nikku/wuffle/pull/299), [#298](https://github.com/nikku/wuffle/issues/298))
+
 ## 0.73.2
 
 * `FIX`: ensure automatic dev flow adheres to `ignoreFilter` ([#296](https://github.com/nikku/wuffle/issues/296), [#297](https://github.com/nikku/wuffle/pull/297))

--- a/packages/app/lib/apps/automatic-dev-flow.js
+++ b/packages/app/lib/apps/automatic-dev-flow.js
@@ -1,6 +1,3 @@
-import { filterIssueOrPull } from '../filters.js';
-import { issueIdent } from '../util/meta.js';
-
 const DONE = 'DONE';
 const EXTERNAL_CONTRIBUTION = 'EXTERNAL_CONTRIBUTION';
 const IN_PROGRESS = 'IN_PROGRESS';
@@ -27,26 +24,7 @@ export default function(webhookEvents, githubIssues, columns, issueFilter, logge
     name: 'wuffle:automatic-dev-flow'
   });
 
-  function ifEnabled(webhookHandlerFn) {
-
-    return (context) => {
-
-      const payload = context.payload;
-
-      const issueOrPull = filterIssueOrPull(
-        payload.issue || payload.pull_request,
-        payload.repository
-      );
-
-      if (issueFilter.isIgnored(issueOrPull)) {
-        log.debug({ issue: issueIdent(issueOrPull) }, 'issue matching ignore filter');
-
-        return;
-      }
-
-      return webhookHandlerFn(context);
-    };
-  }
+  const ifEnabled = issueFilter.createWebhookFilter(log);
 
   webhookEvents.on([
     'issues.closed',

--- a/packages/app/lib/apps/background-sync/BackgroundSync.js
+++ b/packages/app/lib/apps/background-sync/BackgroundSync.js
@@ -395,12 +395,21 @@ We automatically synchronize all repositories you granted us access to via the G
 
     // update changed issues
 
-    await Promise.all(pendingUpdates.map(update => store.updateIssue(update)));
+    const updateTasks = pendingUpdates.map(
+      update => store.updateIssue(update)
+    );
 
-    // emit background sync event for all found issues
+    // returns the update for updated issues or undefined
+    // where issues were not stored (filtered out) - we only filter
+    // for actual updated issues
+    const updatedIssues = await Promise.all(updateTasks).then(updates => {
+      return updates.filter(update => update);
+    });
+
+    // emit background sync event for all updated issues
 
     await syncDetails(
-      Object.keys(foundIssues),
+      updatedIssues,
       getSyncClosedDetailsSince(),
       getSyncOpenDetailsSince()
     );
@@ -437,10 +446,12 @@ We automatically synchronize all repositories you granted us access to via the G
     );
   }
 
-  function syncDetails(issueIds, syncClosedSince, syncOpenSince) {
+  function syncDetails(updatedIssues, syncClosedSince, syncOpenSince) {
 
-    const jobs = issueIds.map(async id => {
-      const issue = await store.getIssueById(id);
+    const jobs = updatedIssues.map(async updatedIssue => {
+
+      // ensure we fetch latest version of issue (to prevent de-sync)
+      const issue = await store.getIssueById(updatedIssue.id);
 
       if (!issue) {
         return;

--- a/packages/app/lib/apps/background-sync/BackgroundSync.js
+++ b/packages/app/lib/apps/background-sync/BackgroundSync.js
@@ -217,25 +217,11 @@ We automatically synchronize all repositories you granted us access to via the G
 
               const update = filterIssueOrPull(issueOrPull, repository);
 
-              const {
-                id
-              } = update;
+              foundIssues[update.id] = update;
 
-              const existingIssue = await store.getIssueById(id);
-
-              if (existingIssue && existingIssue.updated_at >= update.updated_at) {
-                foundIssues[id] = null;
-
-                log.debug({
-                  [type]: `${owner}/${repo}#${issueOrPull.number}`
-                }, 'skipping, as up-to-date');
-              } else {
-                foundIssues[id] = update;
-
-                log.debug({
-                  [type]: `${owner}/${repo}#${issueOrPull.number}`
-                }, 'scheduled for update');
-              }
+              log.debug({
+                [type]: `${owner}/${repo}#${issueOrPull.number}`
+              }, 'scheduled for update');
             } catch (err) {
               log.error({
                 err,

--- a/packages/app/lib/apps/github-comments/GithubComments.js
+++ b/packages/app/lib/apps/github-comments/GithubComments.js
@@ -12,8 +12,16 @@ import gql from 'fake-tag';
  * @param {import('../../events.js').default} events
  * @param {import('../github-client/GithubClient.js').default} githubClient
  * @param {import('../../store.js').default} store
+ * @param {import('../issue-filter/IssueFilter.js').default} issueFilter
+ * @param {import('../../types.js').Logger } logger
  */
-export default function GithubComments(webhookEvents, events, githubClient, store) {
+export default function GithubComments(webhookEvents, events, githubClient, store, issueFilter, logger) {
+
+  const log = logger.child({
+    name: 'wuffle:github-comments'
+  });
+
+  const ifEnabled = issueFilter.createWebhookFilter(log);
 
   // issues /////////////////////
 
@@ -108,7 +116,7 @@ export default function GithubComments(webhookEvents, events, githubClient, stor
 
   webhookEvents.on([
     'issue_comment'
-  ], async ({ payload }) => {
+  ], ifEnabled(async ({ payload }) => {
     const {
       action,
       comment: _comment,
@@ -169,7 +177,7 @@ export default function GithubComments(webhookEvents, events, githubClient, stor
       ...commentedIssue,
       comments
     });
-  });
+  }));
 
 }
 

--- a/packages/app/lib/apps/github-reviews/GithubReviews.js
+++ b/packages/app/lib/apps/github-reviews/GithubReviews.js
@@ -11,8 +11,16 @@ import { filterUser, filterPull } from '../../filters.js';
  * @param {import('../../events.js').default} events
  * @param {import('../github-client/GithubClient.js').default} githubClient
  * @param {import('../../store.js').default} store
+ * @param {import('../issue-filter/IssueFilter.js').default} issueFilter
+ * @param {import('../../types.js').Logger } logger
  */
-export default function GithubReviews(webhookEvents, events, githubClient, store) {
+export default function GithubReviews(webhookEvents, events, githubClient, store, issueFilter, logger) {
+
+  const log = logger.child({
+    name: 'wuffle:github-reviews'
+  });
+
+  const ifEnabled = issueFilter.createWebhookFilter(log);
 
   // issues /////////////////////
 
@@ -54,7 +62,7 @@ export default function GithubReviews(webhookEvents, events, githubClient, store
 
   webhookEvents.on([
     'pull_request_review'
-  ], async ({ payload }) => {
+  ], ifEnabled(async ({ payload }) => {
     const {
       action,
       review: _review,
@@ -102,7 +110,7 @@ export default function GithubReviews(webhookEvents, events, githubClient, store
       ...pull_request,
       reviews
     });
-  });
+  }));
 
 }
 

--- a/packages/app/lib/apps/github-statuses/GithubStatuses.js
+++ b/packages/app/lib/apps/github-statuses/GithubStatuses.js
@@ -11,8 +11,16 @@ import { filterPull } from '../../filters.js';
  * @param {import('../../events.js').default} events
  * @param {import('../github-client/GithubClient.js').default} githubClient
  * @param {import('../../store.js').default} store
+ * @param {import('../issue-filter/IssueFilter.js').default} issueFilter
+ * @param {import('../../types.js').Logger } logger
  */
-export default function GithubStates(webhookEvents, events, githubClient, store) {
+export default function GithubStatuses(webhookEvents, events, githubClient, store, issueFilter, logger) {
+
+  const log = logger.child({
+    name: 'wuffle:github-statuses'
+  });
+
+  const ifEnabled = issueFilter.createWebhookFilter(log);
 
   // issues /////////////////////
 
@@ -89,7 +97,7 @@ export default function GithubStates(webhookEvents, events, githubClient, store)
   webhookEvents.on([
     'pull_request.opened',
     'pull_request.synchronize'
-  ], async ({ payload }) => {
+  ], ifEnabled(async ({ payload }) => {
 
     const {
       pull_request: _pull_request,
@@ -108,7 +116,7 @@ export default function GithubStates(webhookEvents, events, githubClient, store)
       id,
       statuses
     });
-  });
+  }));
 
   webhookEvents.on([
     'status'

--- a/packages/app/lib/apps/issue-filter/IssueFilter.js
+++ b/packages/app/lib/apps/issue-filter/IssueFilter.js
@@ -21,16 +21,16 @@ export default function IssueFilter(config, store, search, logger) {
   /**
    * @type { import('../search/Search.js').FilterFn }
    */
-  let ignoreFilter = (issue) => false;
+  let isIgnored = (issue) => false;
 
 
   if ('ignoreFilter' in config) {
     const ignoreFilterFn = search.buildFilterFn(config.ignoreFilter);
 
     if (ignoreFilterFn) {
-      ignoreFilter = ignoreFilterFn;
+      isIgnored = ignoreFilterFn;
 
-      store.setIgnoreFilter(ignoreFilter);
+      store.setIgnoreFilter(isIgnored);
     } else {
       log.warn('unparseable <ignoreFilter> - please correct your board configuration');
     }
@@ -43,8 +43,6 @@ export default function IssueFilter(config, store, search, logger) {
    *
    * @return {boolean} true, if issue shall be ignored
    */
-  this.isIgnored = function(issue) {
-    return ignoreFilter(issue);
-  };
+  this.isIgnored = isIgnored;
 
 }

--- a/packages/app/lib/apps/issue-filter/IssueFilter.js
+++ b/packages/app/lib/apps/issue-filter/IssueFilter.js
@@ -2,12 +2,14 @@
  * @typedef { { ignoreFilter?: string } } StoreFilterConfig
  */
 
+import { filterIssueOrPull } from '../../filters.js';
+import { issueIdent } from '../../util/meta.js';
+
 /**
  * An component that configures the store to filter certain elements,
  * effectively making them invisible to the board and its users.
  *
  * @param { StoreFilterConfig } config
- *
  * @param { import('../../store.js').default } store
  * @param { import('../search/Search.js').default } search
  * @param { import('../../types.js').Logger } logger
@@ -37,6 +39,35 @@ export default function IssueFilter(config, store, search, logger) {
   }
 
   /**
+   * @param {import('../../types.js').Logger } log
+   *
+   * @return { (filterFn) => (any) => any }
+   */
+  function createWebhookFilter(log) {
+
+    return function ifEnabled(webhookHandlerFn) {
+
+      return (context) => {
+
+        const payload = context.payload;
+
+        const issueOrPull = filterIssueOrPull(
+          payload.issue || payload.pull_request,
+          payload.repository
+        );
+
+        if (isIgnored(issueOrPull)) {
+          log.debug({ issue: issueIdent(issueOrPull) }, 'issue matching ignore filter');
+
+          return;
+        }
+
+        return webhookHandlerFn(context);
+      };
+    };
+  };
+
+  /**
    * Figure whether the issue shall be ignored (by ignore filter rules)
    *
    * @param {any} issue
@@ -45,4 +76,10 @@ export default function IssueFilter(config, store, search, logger) {
    */
   this.isIgnored = isIgnored;
 
+  /**
+   * @param {import('../../types.js').Logger } log
+   *
+   * @return { (filterFn) => (any) => any }
+   */
+  this.createWebhookFilter = createWebhookFilter;
 }


### PR DESCRIPTION
### Which issue does this PR address?

Closes https://github.com/nikku/wuffle/issues/298

* Now background sync always synchronizes issue core (it always synchronized details anyway)
* Now comments, status and checks are only synchronized for issues in the store